### PR TITLE
[TAS-174] refactor: 중첩 네비게이터 구조로 변경

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,7 +4,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { Login } from 'screens/Login';
-import { BottomTabNavigator } from 'components/navigators/BottomTabNavigator';
+import { HomeStackNavigator } from 'components/navigators/Stack/Home';
 import { ThemeContext } from 'hooks/shared/useTheme';
 import { theme } from 'styles/theme';
 import { Signup } from 'screens/Signup';
@@ -18,7 +18,7 @@ function App(): React.JSX.Element {
       <View style={styles.container}>
         {isLoggedIn ? (
           <SafeAreaProvider>
-            <NavigationContainer>{isNeedSignUp ? <Signup /> : <BottomTabNavigator />}</NavigationContainer>
+            <NavigationContainer>{isNeedSignUp ? <Signup /> : <HomeStackNavigator />}</NavigationContainer>
           </SafeAreaProvider>
         ) : (
           <Login setIsLoggedIn={setIsLoggedIn} />

--- a/src/components/Signup/UserInfo/index.tsx
+++ b/src/components/Signup/UserInfo/index.tsx
@@ -4,7 +4,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Controller, useFormContext } from 'react-hook-form';
 import DropDownPicker from 'react-native-dropdown-picker';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
-import { NativeStackScreenProps } from 'react-native-screens/native-stack';
 import { HelperText } from 'react-native-paper';
 import DatePicker from 'react-native-date-picker';
 import dayjs from 'dayjs';
@@ -12,12 +11,10 @@ import Popover from 'react-native-popover-view';
 
 import { theme } from 'styles/theme';
 import { isAos } from 'utils/device';
-import { RootStackParamList } from 'types/shared';
+import type { SignUpStackScreenProps } from 'types/shared';
 import { QuestionCircle } from 'components/common/icons/QuestionCircle';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'SIGN_UP_USER_INFO'>;
-
-const UserInfo = ({ navigation: { navigate } }: Props) => {
+const UserInfo = ({ navigation: { navigate } }: SignUpStackScreenProps<'SIGN_UP_USER_INFO'>) => {
   const {
     control,
     watch,

--- a/src/components/navigators/Stack/Home/index.tsx
+++ b/src/components/navigators/Stack/Home/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { theme } from 'styles/theme';
+import { createStackNavigator } from '@react-navigation/stack';
+import { SettingStackNavigator } from 'components/navigators/Stack/Mypage';
+import { BottomTabNavigator } from 'components/navigators/Tab/Home';
+import type { RootStackParamList } from 'types/shared';
+
+const HomeStackNavigator = () => {
+  const { Navigator, Screen } = createStackNavigator<RootStackParamList>();
+
+  return (
+    <Navigator
+      initialRouteName="HOME"
+      screenOptions={{
+        headerTitleAlign: 'center',
+        headerBackTitleVisible: false,
+        headerTintColor: theme.COLORS.DEFAULT.BLACK,
+      }}
+    >
+      <Screen name="HOME" component={BottomTabNavigator} options={{ headerShown: false }} />
+      <Screen name="SETTING" component={SettingStackNavigator} options={{ headerShown: false }} />
+    </Navigator>
+  );
+};
+
+export { HomeStackNavigator };

--- a/src/components/navigators/Stack/Mypage/index.tsx
+++ b/src/components/navigators/Stack/Mypage/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { createStackNavigator } from '@react-navigation/stack';
+
+import { theme } from 'styles/theme';
+import { Setting } from 'screens/Mypage/Setting';
+import { Myinfo } from 'screens/Mypage/Setting/Myinfo';
+import type { SettingStackParamList } from 'types/shared';
+
+const SettingStackNavigator = () => {
+  const { Navigator, Screen } = createStackNavigator<SettingStackParamList>();
+  return (
+    <Navigator
+      initialRouteName="DEFAULT"
+      screenOptions={{
+        headerTitleAlign: 'center',
+        headerBackTitleVisible: false,
+        headerTintColor: theme.COLORS.DEFAULT.BLACK,
+      }}
+    >
+      <Screen name="DEFAULT" component={Setting} options={{ headerTitle: '설정' }} />
+      <Screen name="MYINFO" component={Myinfo} options={{ headerTitle: '내 정보 관리' }} />
+    </Navigator>
+  );
+};
+
+export { SettingStackNavigator };

--- a/src/components/navigators/Stack/Signup/index.tsx
+++ b/src/components/navigators/Stack/Signup/index.tsx
@@ -4,14 +4,10 @@ import { createStackNavigator } from '@react-navigation/stack';
 import { ServiceAgree } from 'components/Signup/ServiceAgree';
 import { UserInfo } from 'components/Signup/UserInfo';
 import { theme } from 'styles/theme';
-
-export type RootStackParamList = {
-  SIGN_UP_USER_INFO: undefined;
-  SIGN_UP_AGREEMENT: undefined;
-};
+import type { SignUpStackParamList } from 'types/shared';
 
 const SignupStackNavigator = () => {
-  const { Navigator, Screen } = createStackNavigator<RootStackParamList>();
+  const { Navigator, Screen } = createStackNavigator<SignUpStackParamList>();
   return (
     <Navigator
       initialRouteName="SIGN_UP_USER_INFO"

--- a/src/components/navigators/Tab/Home/index.tsx
+++ b/src/components/navigators/Tab/Home/index.tsx
@@ -9,18 +9,18 @@ import { Mypage } from 'screens/Mypage';
 import { HomeIcon } from 'components/common/icons/HomeIcon';
 import { FeedIcon } from 'components/common/icons/FeedIcon';
 import { MypageIcon } from 'components/common/icons/MypageIcon';
-import type { BottomTabParamList } from 'types/shared';
 import { theme } from 'styles/theme';
+import type { HomeTabParamList, RootStackScreenProps } from 'types/shared';
 
-const BottomTabNavigator = () => {
-  const { Navigator, Screen } = createBottomTabNavigator<BottomTabParamList>();
+const BottomTabNavigator = ({ navigation }: RootStackScreenProps<'HOME'>) => {
+  const { Navigator, Screen } = createBottomTabNavigator<HomeTabParamList>();
   const {
     COLORS: { DEFAULT, PRIMARY, GRAY_SCALE },
   } = useTheme();
 
   return (
     <Navigator
-      initialRouteName="HOME"
+      initialRouteName="MYTODO"
       screenOptions={{
         headerTitleAlign: 'center',
         tabBarActiveTintColor: PRIMARY.RED_500,
@@ -42,7 +42,7 @@ const BottomTabNavigator = () => {
         }}
       />
       <Screen
-        name="HOME"
+        name="MYTODO"
         component={Home}
         options={{
           headerTitle: '마이투두',
@@ -73,7 +73,7 @@ const BottomTabNavigator = () => {
               iconColor={theme.COLORS.DEFAULT.BLACK}
               size={18}
               onPress={() => {
-                console.log('click');
+                navigation.navigate('SETTING');
               }}
             />
           ),

--- a/src/screens/Mypage/Setting/Myinfo/index.tsx
+++ b/src/screens/Mypage/Setting/Myinfo/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+const Myinfo = () => (
+  <View>
+    <Text>내 정보 관리</Text>
+  </View>
+);
+
+export { Myinfo };

--- a/src/screens/Mypage/Setting/index.tsx
+++ b/src/screens/Mypage/Setting/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+import type { SettingStackScreenProps } from 'types/shared';
+
+const Setting = ({ navigation: { navigate } }: SettingStackScreenProps<'DEFAULT'>) => {
+  return (
+    <View>
+      <Pressable
+        onPress={() => {
+          navigate('MYINFO');
+        }}
+      >
+        <Text>클릭하면 내 정보 관리 스크린으로 이동</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+export { Setting };

--- a/src/types/shared/index.ts
+++ b/src/types/shared/index.ts
@@ -1,12 +1,48 @@
-type RootStackParamList = {
+import type { StackScreenProps } from '@react-navigation/stack';
+import { CompositeScreenProps } from '@react-navigation/native';
+import { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
+
+type SignUpStackParamList = {
   SIGN_UP_USER_INFO: undefined;
   SIGN_UP_AGREEMENT: undefined;
 };
 
-type BottomTabParamList = {
+type SignUpStackScreenProps<T extends keyof SignUpStackParamList> = StackScreenProps<SignUpStackParamList, T>;
+
+type RootStackParamList = {
   HOME: undefined;
+  SETTING: undefined;
+};
+
+type RootStackScreenProps<T extends keyof RootStackParamList> = StackScreenProps<RootStackParamList, T>;
+
+type HomeTabParamList = {
+  MYTODO: undefined;
   FEED: undefined;
   MYPAGE: undefined;
 };
 
-export type { RootStackParamList, BottomTabParamList };
+type HomeTabScreenProps<T extends keyof HomeTabParamList> = CompositeScreenProps<
+  BottomTabScreenProps<HomeTabParamList, T>,
+  RootStackScreenProps<keyof RootStackParamList>
+>;
+
+type SettingStackParamList = {
+  DEFAULT: undefined;
+  MYINFO: undefined;
+  NOTIFICATION: undefined;
+  POLICY: undefined;
+};
+
+type SettingStackScreenProps<T extends keyof SettingStackParamList> = StackScreenProps<SettingStackParamList, T>;
+
+export type {
+  SignUpStackParamList,
+  SignUpStackScreenProps,
+  RootStackParamList,
+  RootStackScreenProps,
+  HomeTabParamList,
+  HomeTabScreenProps,
+  SettingStackParamList,
+  SettingStackScreenProps,
+};


### PR DESCRIPTION
## 🤔 개요
<!-- 해당 작업을 하게 된 배경에 대해 적어주세요 -->
내 정보 화면의 설정 화면을 구현하기 위해 중첩 네비게이터 구조로 변환해야 함

## 📝 작업 내용
<!-- 작업한 내용을 정리하여 적어주세요 -->
1. 중첩 네비게이터 구조로 변환 (Tab Navigatior, Stack Navigator)
2. 네비게이터 타입 제네릭으로 확장
3. 스크린 이름 중첩되지 않게 수정
4. 설정 및 내 정보 관리 화면 추가 및 라우트 연결

## 📸 작업 화면
<table>
<tr>
<td>🤖 AOS</td>
<td>🍎 IOS</td>
</tr>
<tr>

<td>

https://github.com/user-attachments/assets/62e141b1-3166-4c01-aa13-fb5fa41ba6ea
</td>
<td>

https://github.com/user-attachments/assets/aa41f90b-ff80-4ae8-9768-2ced86d81d0b
</td>
</tr>
</table>


## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->
[Nesting navigators](https://reactnavigation.org/docs/nesting-navigators)
[Type checking with TypeScript](https://reactnavigation.org/docs/typescript/#specifying-default-types-for-usenavigation-link-ref-etc)

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-174](https://www.notion.so/ba97f4005a384244ab4b89fd451cfc0f?pvs=4)