### PR TITLE
[TAS-179] add: 보유한 뱃지 화면 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "LetMeDoWith",
       "version": "0.0.1",
       "dependencies": {
+        "@gorhom/bottom-sheet": "^4.6.4",
         "@invertase/react-native-apple-authentication": "^2.3.0",
         "@react-native-google-signin/google-signin": "^11.0.0",
         "@react-native-masked-view/masked-view": "^0.3.1",
@@ -2425,6 +2426,43 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@gorhom/bottom-sheet": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-4.6.4.tgz",
+      "integrity": "sha512-0itLMblLBvepE065w3a60S030c2rNUsGshPC7wbWDm31VyqoaU2xjzh/ojH62YIJOcobBr5QoC30IxBBKDGovQ==",
+      "dependencies": {
+        "@gorhom/portal": "1.0.14",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=1.10.1",
+        "react-native-reanimated": ">=2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gorhom/portal": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -4348,14 +4386,14 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.48",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
       "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4377,7 +4415,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -6007,7 +6045,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@gorhom/bottom-sheet": "^4.6.4",
     "@invertase/react-native-apple-authentication": "^2.3.0",
     "@react-native-google-signin/google-signin": "^11.0.0",
     "@react-native-masked-view/masked-view": "^0.3.1",

--- a/src/components/Mypage/Badge/index.tsx
+++ b/src/components/Mypage/Badge/index.tsx
@@ -1,40 +1,77 @@
-import React, { useCallback } from 'react';
-import { Image, Pressable, StyleSheet, Text } from 'react-native';
+import React from 'react';
+import { Dimensions, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { IconButton } from 'react-native-paper';
 
 import { theme } from 'styles/theme';
 
 interface Props {
   uri: string;
-  name: string;
-  size: number;
+  name?: string;
+  isRepresentative?: boolean;
+  onPress?: () => void;
 }
 
-const Badge = ({ uri, name, size }: Props) => {
-  const handlePress = useCallback(() => {
-    console.log('click!');
-  }, []);
+const size = Dimensions.get('window').width / 3 - 48;
 
-  return (
-    <Pressable style={styles.container} onPress={handlePress}>
-      <Image
-        borderRadius={50}
-        width={size}
-        height={size}
-        source={{
-          uri,
-        }}
-      />
-      <Text style={styles.name}>{name}</Text>
-    </Pressable>
-  );
-};
+const Badge = ({ uri, name, isRepresentative, onPress }: Props) => (
+  <Pressable style={styles.container} onPress={onPress}>
+    {uri ? (
+      <>
+        {isRepresentative && (
+          <View style={styles.representativeBadge}>
+            <Text style={styles.representativeText}>대표</Text>
+          </View>
+        )}
+        <Image
+          style={isRepresentative && styles.representativeImage}
+          borderRadius={50}
+          width={size}
+          height={size}
+          source={{
+            uri,
+          }}
+        />
+      </>
+    ) : (
+      <View style={styles.emptyBadge}>
+        <IconButton icon="lock" iconColor={theme.COLORS.DEFAULT.WHITE} size={35} />
+      </View>
+    )}
+    {name && <Text style={styles.name}>{name}</Text>}
+  </Pressable>
+);
 
 const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     gap: 16,
   },
+  emptyBadge: {
+    borderRadius: 40,
+    width: size,
+    height: size,
+    backgroundColor: theme.COLORS.GRAY_SCALE.GRAY_600,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   name: { fontSize: 14, fontWeight: 'bold', color: theme.COLORS.DEFAULT.BLACK },
+  representativeBadge: {
+    position: 'absolute',
+    top: -5,
+    zIndex: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 15,
+    backgroundColor: theme.COLORS.PRIMARY.RED_500,
+  },
+  representativeText: {
+    color: theme.COLORS.DEFAULT.WHITE,
+    fontSize: 10,
+  },
+  representativeImage: {
+    borderWidth: 2,
+    borderColor: theme.COLORS.PRIMARY.RED_500,
+  },
 });
 
 export { Badge };

--- a/src/components/Mypage/Badge/index.tsx
+++ b/src/components/Mypage/Badge/index.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback } from 'react';
+import { Image, Pressable, StyleSheet, Text } from 'react-native';
+
+import { theme } from 'styles/theme';
+
+interface Props {
+  uri: string;
+  name: string;
+  size: number;
+}
+
+const Badge = ({ uri, name, size }: Props) => {
+  const handlePress = useCallback(() => {
+    console.log('click!');
+  }, []);
+
+  return (
+    <Pressable style={styles.container} onPress={handlePress}>
+      <Image
+        borderRadius={50}
+        width={size}
+        height={size}
+        source={{
+          uri,
+        }}
+      />
+      <Text style={styles.name}>{name}</Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: 16,
+  },
+  name: { fontSize: 14, fontWeight: 'bold', color: theme.COLORS.DEFAULT.BLACK },
+});
+
+export { Badge };

--- a/src/components/navigators/Stack/Mypage/index.tsx
+++ b/src/components/navigators/Stack/Mypage/index.tsx
@@ -6,6 +6,7 @@ import { Setting } from 'screens/Mypage/Setting';
 import { Myinfo } from 'screens/Mypage/Setting/Myinfo';
 import { Notification } from 'screens/Mypage/Setting/Notification';
 import { Policy } from 'screens/Mypage/Setting/Policy';
+import { BadgeInfo } from 'screens/Mypage/Setting/BadgeInfo';
 import type { SettingStackParamList } from 'types/shared';
 
 const SettingStackNavigator = () => {
@@ -24,6 +25,7 @@ const SettingStackNavigator = () => {
       <Screen name="MYINFO" component={Myinfo} options={{ headerTitle: '내 정보 관리' }} />
       <Screen name="NOTIFICATION" component={Notification} options={{ headerTitle: '알림설정' }} />
       <Screen name="POLICY" component={Policy} options={{ headerTitle: '이용약관' }} />
+      <Screen name="BADGE_INFO" component={BadgeInfo} options={{ headerTitle: '보유한 뱃지' }} />
     </Navigator>
   );
 };

--- a/src/screens/Mypage/Setting/BadgeInfo/index.tsx
+++ b/src/screens/Mypage/Setting/BadgeInfo/index.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Dimensions, FlatList, StyleSheet, Text, View } from 'react-native';
+import { Divider } from 'react-native-paper';
+
+import { Badge } from 'components/Mypage/Badge';
+import { theme } from 'styles/theme';
+
+const mockData = Array(9)
+  .fill(undefined)
+  .map((_, index) => ({
+    uri: 'https://media.bunjang.co.kr/images/crop/981758465_w320.jpg',
+    name: `test 뱃지${index + 1}`,
+  }));
+
+const size = Dimensions.get('window').width / 3 - 48;
+
+const BadgeInfo = () => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.titleWrap}>
+        <Text style={styles.title}>나의 대표 뱃지</Text>
+        <Text style={styles.subTitle}>피드에 노출되는 대표 뱃지입니다.</Text>
+      </View>
+      <Badge uri={'https://media.bunjang.co.kr/images/crop/981758465_w320.jpg'} name={'프로 미룸러'} size={size} />
+
+      <Divider style={styles.divider} />
+      <Text>* 대표 뱃지 포함 최대 4개까지 노출할 수 있습니다.</Text>
+      <FlatList
+        style={{ width: '100%', marginTop: 32 }}
+        data={mockData}
+        renderItem={({ item: { uri, name } }) => <Badge uri={uri} name={name} size={size} />}
+        keyExtractor={({ name }) => name}
+        numColumns={3}
+        ItemSeparatorComponent={() => <View style={{ marginTop: 32 }}></View>}
+        columnWrapperStyle={{
+          justifyContent: 'space-between',
+          flexDirection: 'row',
+        }}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingVertical: 32,
+    alignItems: 'center',
+  },
+  titleWrap: {
+    gap: 16,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    color: theme.COLORS.DEFAULT.BLACK,
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  subTitle: {
+    color: theme.COLORS.GRAY_SCALE.GRAY_600,
+  },
+  divider: {
+    width: '100%',
+    marginVertical: 14,
+    borderWidth: 0.5,
+    borderColor: theme.COLORS.GRAY_SCALE.GRAY_300,
+    borderStyle: 'dashed',
+  },
+});
+
+export { BadgeInfo };

--- a/src/screens/Mypage/Setting/BadgeInfo/index.tsx
+++ b/src/screens/Mypage/Setting/BadgeInfo/index.tsx
@@ -1,43 +1,133 @@
-import React from 'react';
-import { Dimensions, FlatList, StyleSheet, Text, View } from 'react-native';
+import React, { useCallback, useRef, useState } from 'react';
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
 import { Divider } from 'react-native-paper';
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetModalProvider, BottomSheetView } from '@gorhom/bottom-sheet';
+import type { BottomSheetBackdropProps } from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop';
 
 import { Badge } from 'components/Mypage/Badge';
 import { theme } from 'styles/theme';
+import { isAos } from 'utils/device';
 
-const mockData = Array(9)
+type BadgeInfo = {
+  uri: string;
+  name: string;
+  description: string;
+  isRepresentative: boolean;
+};
+
+const mockData: BadgeInfo[] = Array(9)
   .fill(undefined)
-  .map((_, index) => ({
-    uri: 'https://media.bunjang.co.kr/images/crop/981758465_w320.jpg',
-    name: `test 뱃지${index + 1}`,
-  }));
+  .map((_, index) =>
+    index < 2
+      ? {
+          uri: 'https://media.bunjang.co.kr/images/crop/981758465_w320.jpg',
+          name: `test 뱃지${index + 1}`,
+          description:
+            '3번 이상 두윗 모드를 이행하지 않거나\n상태가 (빨간불)인 사용자에게 부여되는 뱃지로특정 행위를 하기 전, 해지할 수 없습니다',
+          isRepresentative: index === 1,
+        }
+      : {
+          uri: '',
+          name: `test 뱃지${index + 1}`,
+          description: `test 뱃지${
+            index + 1
+          }는 어쩌구저쩌구\n얻기 위해서 어쩌구저쩌구 노력을해주세요.\n화이팅화이팅해주세요.`,
+          isRepresentative: false,
+        },
+  );
 
-const size = Dimensions.get('window').width / 3 - 48;
+const initialSnapPoints = isAos ? ['75%'] : ['52%'];
 
 const BadgeInfo = () => {
-  return (
-    <View style={styles.container}>
-      <View style={styles.titleWrap}>
-        <Text style={styles.title}>나의 대표 뱃지</Text>
-        <Text style={styles.subTitle}>피드에 노출되는 대표 뱃지입니다.</Text>
-      </View>
-      <Badge uri={'https://media.bunjang.co.kr/images/crop/981758465_w320.jpg'} name={'프로 미룸러'} size={size} />
+  const bottomSheetContentRef = useRef<View>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
-      <Divider style={styles.divider} />
-      <Text>* 대표 뱃지 포함 최대 4개까지 노출할 수 있습니다.</Text>
-      <FlatList
-        style={{ width: '100%', marginTop: 32 }}
-        data={mockData}
-        renderItem={({ item: { uri, name } }) => <Badge uri={uri} name={name} size={size} />}
-        keyExtractor={({ name }) => name}
-        numColumns={3}
-        ItemSeparatorComponent={() => <View style={{ marginTop: 32 }}></View>}
-        columnWrapperStyle={{
-          justifyContent: 'space-between',
-          flexDirection: 'row',
-        }}
-      />
-    </View>
+  const [snapPoints, setSnapPoints] = useState<string[]>(initialSnapPoints);
+  const [isButtonVisible, setIsButtonVisible] = useState<boolean>(true);
+  const [selectedBadgeInfo, setSelectedBadgeInfo] = useState<BadgeInfo | null>(null);
+
+  const handlePresentModalPress = useCallback((badgeInfo: BadgeInfo) => {
+    bottomSheetModalRef.current?.present();
+    setSelectedBadgeInfo(badgeInfo);
+    setIsButtonVisible(!!badgeInfo.uri && !badgeInfo.isRepresentative);
+
+    if (!!badgeInfo.uri && !badgeInfo.isRepresentative) {
+      setSnapPoints(initialSnapPoints);
+      return;
+    }
+
+    setSnapPoints(isAos ? ['55%'] : ['40%']);
+  }, []);
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => <BottomSheetBackdrop disappearsOnIndex={-1} appearsOnIndex={0} {...props} />,
+    [],
+  );
+
+  const renderItemSeparatorComponent = useCallback(() => <View style={styles.flatListSeperator} />, []);
+
+  const handleSubmit = useCallback(() => {
+    // TODO: API 연동
+    console.log('대표 뱃지 변경');
+  }, []);
+
+  return (
+    <BottomSheetModalProvider>
+      <View style={styles.container}>
+        <View style={styles.titleWrap}>
+          <Text style={styles.title}>나의 대표 뱃지</Text>
+          <Text style={styles.subTitle}>피드에 노출되는 대표 뱃지입니다.</Text>
+        </View>
+        <Badge uri={'https://media.bunjang.co.kr/images/crop/981758465_w320.jpg'} name="test 뱃지2" />
+        <Divider style={styles.divider} />
+        <Text>* 대표 뱃지 포함 최대 4개까지 노출할 수 있습니다.</Text>
+        <FlatList
+          contentContainerStyle={styles.flatListContentContainer}
+          style={styles.flatListContainer}
+          data={mockData}
+          renderItem={({ item: { uri, name, description, isRepresentative } }) => (
+            <Badge
+              uri={uri}
+              name={name}
+              isRepresentative={isRepresentative}
+              onPress={() => handlePresentModalPress({ uri, name, description, isRepresentative })}
+            />
+          )}
+          keyExtractor={({ name }) => name}
+          numColumns={3}
+          ItemSeparatorComponent={renderItemSeparatorComponent}
+          columnWrapperStyle={styles.flatListColumnWrapper}
+        />
+        <BottomSheetModal
+          ref={bottomSheetModalRef}
+          index={0}
+          snapPoints={snapPoints}
+          backdropComponent={renderBackdrop}
+        >
+          <BottomSheetView style={styles.modalContainer}>
+            <View ref={bottomSheetContentRef}>
+              <View style={styles.modalTitleWrap}>
+                <Text style={styles.modalTitle}>{selectedBadgeInfo?.name}</Text>
+              </View>
+              <View style={styles.badgeImageWrap}>
+                <Badge uri={selectedBadgeInfo?.uri || ''} />
+              </View>
+              <View style={styles.modalDescriptionWrap}>
+                <Text style={styles.modalDescription}>{selectedBadgeInfo?.description}</Text>
+              </View>
+            </View>
+            {isButtonVisible && (
+              <Pressable
+                style={[styles.button, !isButtonVisible && { backgroundColor: theme.COLORS.PRIMARY.RED_500 }]}
+                onPress={handleSubmit}
+              >
+                <Text style={styles.buttonText}>대표 뱃지로 설정하기</Text>
+              </Pressable>
+            )}
+          </BottomSheetView>
+        </BottomSheetModal>
+      </View>
+    </BottomSheetModalProvider>
   );
 };
 
@@ -68,6 +158,51 @@ const styles = StyleSheet.create({
     borderColor: theme.COLORS.GRAY_SCALE.GRAY_300,
     borderStyle: 'dashed',
   },
+  modalContainer: {
+    flex: 1,
+    justifyContent: 'space-between',
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 32,
+  },
+  modalTitleWrap: {
+    alignItems: 'center',
+  },
+  modalTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: theme.COLORS.DEFAULT.BLACK,
+  },
+  badgeImageWrap: {
+    alignItems: 'center',
+    marginTop: 32,
+    marginBottom: 22,
+  },
+  modalDescriptionWrap: {
+    alignItems: 'center',
+  },
+  modalDescription: {
+    fontSize: 16,
+    textAlign: 'center',
+    color: theme.COLORS.GRAY_SCALE.GRAY_700,
+  },
+  button: {
+    borderRadius: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: 64,
+    backgroundColor: theme.COLORS.PRIMARY.RED_500,
+  },
+  buttonText: {
+    fontSize: 18,
+    color: theme.COLORS.DEFAULT.WHITE,
+  },
+  flatListContentContainer: {
+    paddingTop: 5,
+  },
+  flatListContainer: { width: '100%', marginTop: 27 },
+  flatListSeperator: { marginTop: 32 },
+  flatListColumnWrapper: { justifyContent: 'space-between', flexDirection: 'row' },
 });
 
 export { BadgeInfo };

--- a/src/screens/Mypage/Setting/Myinfo/index.tsx
+++ b/src/screens/Mypage/Setting/Myinfo/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Dimensions, Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { Controller, useForm } from 'react-hook-form';
-import { HelperText, TextInput } from 'react-native-paper';
+import { HelperText, IconButton, TextInput } from 'react-native-paper';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
 import { getBottomSpace } from 'react-native-iphone-screen-helper';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
@@ -11,13 +11,14 @@ import { isAos } from 'utils/device';
 import { BasicMenu } from 'components/Mypage/Setting/Menu';
 import { ConfirmModal } from 'components/common/Modal';
 import { DELETE_ACCOUNT_CONFIRM_MODAL_CONTENT, LOGOUT_CONFIRM_MODAL_CONTENT } from 'constants/Mypage';
+import type { SettingStackScreenProps } from 'types/shared';
 
 type FormData = {
   nickname: string;
   description: string;
 };
 
-const Myinfo = () => {
+const Myinfo = ({ navigation: { navigate } }: SettingStackScreenProps<'MYINFO'>) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalType, setModalType] = useState<'LOGOUT' | 'DELETE_ACCOUNT' | null>(null);
 
@@ -84,8 +85,9 @@ const Myinfo = () => {
       <View style={styles.contentWrap}>
         <View style={styles.imageWrap}>
           <Pressable
+            style={{ width: 50, height: 50 }}
             onPress={() => {
-              console.log('click');
+              navigate('BADGE_INFO');
             }}
           >
             <Image
@@ -93,6 +95,12 @@ const Myinfo = () => {
               source={{
                 uri: 'https://ichef.bbci.co.uk/news/1536/cpsprodpb/16620/production/_91408619_55df76d5-2245-41c1-8031-07a4da3f313f.jpg.webp',
               }}
+            />
+            <IconButton
+              style={{ position: 'relative', left: 25, bottom: 25 }}
+              icon="pencil-circle"
+              iconColor={theme.COLORS.GRAY_SCALE.GRAY_500}
+              size={22}
             />
           </Pressable>
           <Text style={styles.badgeText}>뉴비기너</Text>
@@ -240,8 +248,9 @@ const styles = StyleSheet.create({
     marginTop: 12,
   },
   image: {
-    width: 50,
-    height: 50,
+    borderRadius: 10,
+    width: '100%',
+    height: '100%',
   },
   formContainer: {
     gap: 26,

--- a/src/types/shared/index.ts
+++ b/src/types/shared/index.ts
@@ -32,6 +32,7 @@ type SettingStackParamList = {
   MYINFO: undefined;
   NOTIFICATION: undefined;
   POLICY: undefined;
+  BADGE_INFO: undefined;
 };
 
 type SettingStackScreenProps<T extends keyof SettingStackParamList> = StackScreenProps<SettingStackParamList, T>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,6 +1206,21 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
+"@gorhom/bottom-sheet@^4.6.4":
+  version "4.6.4"
+  resolved "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-4.6.4.tgz"
+  integrity sha512-0itLMblLBvepE065w3a60S030c2rNUsGshPC7wbWDm31VyqoaU2xjzh/ojH62YIJOcobBr5QoC30IxBBKDGovQ==
+  dependencies:
+    "@gorhom/portal" "1.0.14"
+    invariant "^2.2.4"
+
+"@gorhom/portal@1.0.14":
+  version "1.0.14"
+  resolved "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz"
+  integrity sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==
+  dependencies:
+    nanoid "^3.3.1"
+
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
   resolved "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz"
@@ -5469,7 +5484,7 @@ ms@2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.1.23:
+nanoid@^3.1.23, nanoid@^3.3.1:
   version "3.3.7"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
@@ -6028,7 +6043,7 @@ react-native-dropdown-picker@^5.4.6:
   resolved "https://registry.npmjs.org/react-native-dropdown-picker/-/react-native-dropdown-picker-5.4.6.tgz"
   integrity sha512-T1XBHbE++M6aRU3wFYw3MvcOuabhWZ29RK/Ivdls2r1ZkZ62iEBZknLUPeVLMX3x6iUxj4Zgr3X2DGlEGXeHsA==
 
-react-native-gesture-handler@^2.16.0, "react-native-gesture-handler@>= 1.0.0":
+react-native-gesture-handler@^2.16.0, "react-native-gesture-handler@>= 1.0.0", react-native-gesture-handler@>=1.10.1:
   version "2.16.0"
   resolved "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.16.0.tgz"
   integrity sha512-1hFkx7RIfeJSyTQQ0Nkv4icFVZ5+XjQkd47OgZMBFzoB7ecL+nFSz8KLi3OCWOhq+nbHpSPlSG5VF3CQNCJpWA==
@@ -6066,7 +6081,7 @@ react-native-popover-view@^5.1.8:
     deprecated-react-native-prop-types "^2.3.0"
     prop-types "^15.8.1"
 
-react-native-reanimated@^3.15.0, react-native-reanimated@>=3.0.0:
+react-native-reanimated@^3.15.0, react-native-reanimated@>=2.2.0, react-native-reanimated@>=3.0.0:
   version "3.15.0"
   resolved "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.15.0.tgz"
   integrity sha512-yGxOyYAAu/5CyjonM2SgsM5sviiiK8HiHL9jT1bKfRxMLnNX9cFP8/UXRkbMT7ZXIfOlCvNFR0AqnphpuXIPVA==


### PR DESCRIPTION
## 🤔 개요
<!-- 해당 작업을 하게 된 배경에 대해 적어주세요 -->
보유한 뱃지 UI를 구현해야 함

## 📝 작업 내용
<!-- 작업한 내용을 정리하여 적어주세요 -->
1. 보유한 뱃지 스크린 스택 네비게이터에 추가
2. 보유한 뱃지 화면 UI 구현 
3. 뱃지 설정 관련 바텀 시트 구현

## 📸 작업 화면
<table>
<tr>
<td>🤖 AOS</td>
<td>🍎 IOS</td>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/54b680a7-026c-4459-8a38-2a9bc4d48df6
</td>
<td>

https://github.com/user-attachments/assets/02ade9f2-80a1-4861-ad97-9caecb406ef1
</td>
</tr>
</table>

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->
[gorhom/bottom-sheet](https://ui.gorhom.dev/components/bottom-sheet/)

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-179](https://www.notion.so/UI-afa581b1f40e4f02bf775743cfedab93?pvs=4)