### PR TITLE
[TAS-232] add: 이벤트 & 공지사항 메뉴 UI 구현

### DIFF
--- a/src/components/Mypage/Setting/Notice/Item/index.tsx
+++ b/src/components/Mypage/Setting/Notice/Item/index.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from 'react';
+import { Dimensions, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { theme } from 'styles/theme';
+import type { NoticeType, SettingStackScreenProps } from 'types/shared';
+
+interface Props extends Partial<Pick<SettingStackScreenProps<'NOTICE'>, 'navigation'>> {
+  type: NoticeType;
+  title: string;
+  date: string;
+}
+
+const Item = ({ type, title, date, navigation }: Props) => {
+  const onPress = useCallback(() => {
+    if (!navigation) {
+      return;
+    }
+
+    navigation.navigate('NOTICE_DETAIL', { type, title, date });
+  }, [date, navigation, title, type]);
+
+  return (
+    <Pressable style={styles.container} onPress={onPress}>
+      <View style={styles.contentType}>
+        <Text>[{type === 'NOTICE' ? '공지' : '이벤트'}]</Text>
+      </View>
+      <View style={styles.content}>
+        <Text style={styles.title} numberOfLines={2}>
+          {title}
+        </Text>
+        <Text>{date}</Text>
+      </View>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    paddingTop: 16,
+    paddingBottom: 11,
+    backgroundColor: theme.COLORS.DEFAULT.WHITE,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.COLORS.GRAY_SCALE.GRAY_600,
+  },
+  contentType: {
+    flex: 1,
+  },
+  content: {
+    gap: 14,
+    flex: 4,
+  },
+  title: {
+    width: Dimensions.get('window').width / 1.5,
+  },
+});
+
+export { Item };

--- a/src/components/Mypage/Setting/Notice/index.tsx
+++ b/src/components/Mypage/Setting/Notice/index.tsx
@@ -1,0 +1,1 @@
+export * from './Item';

--- a/src/components/navigators/Stack/Mypage/index.tsx
+++ b/src/components/navigators/Stack/Mypage/index.tsx
@@ -7,6 +7,7 @@ import { Myinfo } from 'screens/Mypage/Setting/Myinfo';
 import { Notification } from 'screens/Mypage/Setting/Notification';
 import { Policy } from 'screens/Mypage/Setting/Policy';
 import { BadgeInfo } from 'screens/Mypage/Setting/BadgeInfo';
+import { NoticeDetail, NoticeList } from 'screens/Mypage/Setting/Notice';
 import type { SettingStackParamList } from 'types/shared';
 
 const SettingStackNavigator = () => {
@@ -24,6 +25,8 @@ const SettingStackNavigator = () => {
       <Screen name="DEFAULT" component={Setting} options={{ headerTitle: '설정' }} />
       <Screen name="MYINFO" component={Myinfo} options={{ headerTitle: '내 정보 관리' }} />
       <Screen name="NOTIFICATION" component={Notification} options={{ headerTitle: '알림설정' }} />
+      <Screen name="NOTICE" component={NoticeList} options={{ headerTitle: '이벤트 & 공지사항' }} />
+      <Screen name="NOTICE_DETAIL" component={NoticeDetail} options={{ headerTitle: '이벤트 & 공지사항' }} />
       <Screen name="POLICY" component={Policy} options={{ headerTitle: '이용약관' }} />
       <Screen name="BADGE_INFO" component={BadgeInfo} options={{ headerTitle: '보유한 뱃지' }} />
     </Navigator>

--- a/src/screens/Mypage/Setting/Notice/Detail/index.tsx
+++ b/src/screens/Mypage/Setting/Notice/Detail/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+
+import { Item } from 'components/Mypage/Setting/Notice';
+import { theme } from 'styles/theme';
+import type { SettingStackScreenProps } from 'types/shared';
+
+const NoticeDetail = ({ route: { params } }: SettingStackScreenProps<'NOTICE_DETAIL'>) => {
+  const { type, title, date } = params;
+
+  return (
+    <View style={styles.container}>
+      <Item type={type} title={title} date={date} />
+      <Text>공지사항 & 이벤트 테스트 내용입니다</Text>
+    </View>
+  );
+};
+const styles = StyleSheet.create({
+  container: {
+    height: Dimensions.get('window').height,
+    paddingHorizontal: 24,
+    gap: 26,
+    backgroundColor: theme.COLORS.DEFAULT.WHITE,
+  },
+});
+
+export { NoticeDetail };

--- a/src/screens/Mypage/Setting/Notice/List/index.tsx
+++ b/src/screens/Mypage/Setting/Notice/List/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import dayjs from 'dayjs';
+
+import { Item } from 'components/Mypage/Setting/Notice';
+import { theme } from 'styles/theme';
+import type { SettingStackScreenProps } from 'types/shared';
+
+const NoticeList = ({ navigation }: SettingStackScreenProps<'NOTICE'>) => (
+  <View style={styles.container}>
+    <Item
+      type="NOTICE"
+      title={'공지사항 일이삼사오육칠팔구영일이삼사오육칠팔구영일이삼사오육칠팔구영일이삼사오육칠팔구여잉ㄹ이삼사오육'}
+      date={dayjs(new Date()).format('YYYY-MM-DD')}
+      navigation={navigation}
+    />
+    <Item
+      type="EVENT"
+      title={'이벤트 일이삼사오육칠팔구영일이삼사오육칠팔구영일이삼사오육칠팔구영일이삼사오육칠팔구여잉ㄹ이삼사오육'}
+      date={dayjs(new Date().setDate(new Date().getDate() - 1)).format('YYYY-MM-DD')}
+      navigation={navigation}
+    />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    paddingHorizontal: 24,
+    backgroundColor: theme.COLORS.DEFAULT.WHITE,
+  },
+});
+
+export { NoticeList };

--- a/src/screens/Mypage/Setting/Notice/index.tsx
+++ b/src/screens/Mypage/Setting/Notice/index.tsx
@@ -1,0 +1,2 @@
+export * from './List';
+export * from './Detail';

--- a/src/screens/Mypage/Setting/index.tsx
+++ b/src/screens/Mypage/Setting/index.tsx
@@ -5,12 +5,23 @@ import type { SettingStackParamList, SettingStackScreenProps } from 'types/share
 import { BasicMenu } from 'components/Mypage/Setting/Menu';
 
 const Setting = ({ navigation: { navigate } }: SettingStackScreenProps<'DEFAULT'>) => {
-  const onPress = useCallback((name: keyof SettingStackParamList) => () => navigate(name), [navigate]);
+  const onPress = useCallback(
+    (name: keyof SettingStackParamList, params?: SettingStackParamList[keyof SettingStackParamList]) => () => {
+      if (name === 'NOTICE_DETAIL' && params) {
+        navigate(name, params);
+        return;
+      }
+
+      navigate(name as Exclude<keyof SettingStackParamList, 'NOTICE_DETAIL'>);
+    },
+    [navigate],
+  );
 
   return (
     <View>
       <BasicMenu title="내 정보 관리" onPress={onPress('MYINFO')} />
       <BasicMenu title="알림설정" onPress={onPress('NOTIFICATION')} />
+      <BasicMenu title="이벤트 & 공지사항" onPress={onPress('NOTICE')} />
       <BasicMenu title="이용약관" onPress={onPress('POLICY')} />
       <BasicMenu title="버전 정보" isArrowVisible={false} content="v0.0.0" />
     </View>

--- a/src/types/shared/index.ts
+++ b/src/types/shared/index.ts
@@ -27,10 +27,18 @@ type HomeTabScreenProps<T extends keyof HomeTabParamList> = CompositeScreenProps
   RootStackScreenProps<keyof RootStackParamList>
 >;
 
+type NoticeType = 'NOTICE' | 'EVENT';
+
 type SettingStackParamList = {
   DEFAULT: undefined;
   MYINFO: undefined;
   NOTIFICATION: undefined;
+  NOTICE: undefined;
+  NOTICE_DETAIL: {
+    type: NoticeType;
+    title: string;
+    date: string;
+  };
   POLICY: undefined;
   BADGE_INFO: undefined;
 };
@@ -46,4 +54,5 @@ export type {
   HomeTabScreenProps,
   SettingStackParamList,
   SettingStackScreenProps,
+  NoticeType,
 };


### PR DESCRIPTION
## 🤔 개요
<!-- 해당 작업을 하게 된 배경에 대해 적어주세요 -->
이벤트 & 공지사항 메뉴 UI를 구현해야 함

## 📝 작업 내용
<!-- 작업한 내용을 정리하여 적어주세요 -->
1. 이벤트 & 공지사항 리스트, 상세 스크린 Stack Navigation 및 타입 추가
2. 이벤트 & 공지사항 메뉴 UI 구현


## 📸 작업 화면
<table>
<tr>
<td>🤖 AOS</td>
<td>🍎 IOS</td>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/f5f6b8dc-a0f5-4c95-a88b-b7c2e9af58b8
</td>
<td>

https://github.com/user-attachments/assets/aa17d357-5845-48c1-a29c-d58e20e0f74e
</td>
</tr>
</table>

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-232](https://www.notion.so/UI-cc6e304513474cf599346a0d76590f99?pvs=4)