### PR TITLE
[TAS-392]add: 테스크 카테고리 api 연동

### DIFF
--- a/src/components/Task/BottomSheet/CategoryBottomSheet/index.tsx
+++ b/src/components/Task/BottomSheet/CategoryBottomSheet/index.tsx
@@ -1,24 +1,13 @@
-import React, { forwardRef, RefObject, useCallback, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useFormContext } from 'react-hook-form';
 import type { BottomSheetModalMethods } from '@gorhom/bottom-sheet/src/types';
 
 import { theme } from 'styles/theme';
 import { BottomSheet } from 'components/common/BottomSheet';
+import { useFetchTaskCategoryList } from 'hooks/queries/task/useFetchTaskCategoryList';
 
-type TaskCategory = { id: number; name: string };
-
-// TODO: Task 카테고리 API 연동
-const MOCK_CATEGORY_LIST = [
-  { id: 1, name: '카테고리1' },
-  { id: 2, name: '카테고리2' },
-  { id: 3, name: '카테고리3' },
-  { id: 4, name: '카테고리4' },
-  { id: 5, name: '카테고리5' },
-  { id: 6, name: '카테고리6' },
-  { id: 7, name: '카테고리7' },
-  { id: 8, name: '카테고리8' },
-];
+type TaskCategory = { id: number; title: string };
 
 interface Props {
   taskCategoryId: number;
@@ -30,6 +19,7 @@ const CategoryBottomSheet = forwardRef<BottomSheetModalMethods, Props>(
     const { setValue } = useFormContext();
     const [selectedCategory, setSelectedCategory] = useState<TaskCategory | null>(null);
     const innerRef = useRef<BottomSheetModalMethods>(null);
+    const { data: taskCategoryList } = useFetchTaskCategoryList();
 
     const onDismissCategoryBottomSheet = useCallback(() => {
       if (taskCategoryId === null) {
@@ -45,9 +35,9 @@ const CategoryBottomSheet = forwardRef<BottomSheetModalMethods, Props>(
     }, [taskCategoryId, prevSelectedCategory]);
 
     const handleCategory = useCallback(
-      ({ id, name }: TaskCategory) =>
+      ({ id, title }: TaskCategory) =>
         () => {
-          setSelectedCategory({ id, name });
+          setSelectedCategory({ id, title });
         },
       [],
     );
@@ -55,7 +45,7 @@ const CategoryBottomSheet = forwardRef<BottomSheetModalMethods, Props>(
     const handleCategoryBottomSheetButton = useCallback(() => {
       setValue('taskCategoryId', selectedCategory?.id);
       innerRef.current?.dismiss();
-    }, [selectedCategory]);
+    }, [selectedCategory?.id, setValue]);
 
     useImperativeHandle(ref, () => innerRef.current!);
 
@@ -69,7 +59,7 @@ const CategoryBottomSheet = forwardRef<BottomSheetModalMethods, Props>(
         handleButtonSubmit={handleCategoryBottomSheetButton}
       >
         <View style={styles.bottomSheetContentContainer}>
-          {MOCK_CATEGORY_LIST.map(({ id, name }) => (
+          {taskCategoryList?.map(({ id, emoji, title }) => (
             <Pressable
               key={id}
               style={[
@@ -79,15 +69,16 @@ const CategoryBottomSheet = forwardRef<BottomSheetModalMethods, Props>(
                   backgroundColor: theme.COLORS.PRIMARY.RED_98,
                 },
               ]}
-              onPress={handleCategory({ id, name })}
+              onPress={handleCategory({ id, title })}
             >
+              <Text>{emoji}</Text>
               <Text
                 style={[
                   styles.categoryButtonName,
                   selectedCategory?.id === id && { color: theme.COLORS.PRIMARY.RED_60 },
                 ]}
               >
-                {name}
+                {title}
               </Text>
             </Pressable>
           ))}
@@ -105,8 +96,11 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   categoryButton: {
-    width: '48%',
+    flexDirection: 'row',
+    justifyContent: 'center',
     alignItems: 'center',
+    gap: 4,
+    width: '48%',
     borderWidth: 1,
     paddingVertical: 12,
     borderColor: theme.COLORS.GRAY_SCALE.GRAY_92,

--- a/src/components/Task/Form/index.tsx
+++ b/src/components/Task/Form/index.tsx
@@ -14,18 +14,7 @@ import { QuestionCircle } from 'components/common/icons/QuestionCircle';
 import type { TaskModeType } from 'types/shared';
 import { CategoryBottomSheet } from 'components/Task/BottomSheet/CategoryBottomSheet';
 import { RoutineBottomSheet } from 'components/Task/BottomSheet/RoutineBottomSheet';
-
-// TODO: Task 카테고리 API 연동
-const MOCK_CATEGORY_LIST = [
-  { id: 1, name: '카테고리1' },
-  { id: 2, name: '카테고리2' },
-  { id: 3, name: '카테고리3' },
-  { id: 4, name: '카테고리4' },
-  { id: 5, name: '카테고리5' },
-  { id: 6, name: '카테고리6' },
-  { id: 7, name: '카테고리7' },
-  { id: 8, name: '카테고리8' },
-];
+import { useFetchTaskCategoryList } from 'hooks/queries/task/useFetchTaskCategoryList';
 
 const Form = () => {
   const { control, watch, setValue, handleSubmit } = useFormContext();
@@ -34,6 +23,7 @@ const Form = () => {
 
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
   const [taskMode, setTaskMode] = useState<TaskModeType | null>(null);
+  const { data: taskCategoryList } = useFetchTaskCategoryList();
 
   const title = watch('title');
   const startDateTime = watch('startDateTime');
@@ -41,7 +31,7 @@ const Form = () => {
 
   const isFormDisabled = taskMode === null;
   const isButtonDisabled = !title || !startDateTime;
-  const prevSelectedCategory = MOCK_CATEGORY_LIST.find(({ id }) => taskCategoryId === id);
+  const prevSelectedCategory = taskCategoryList?.find(({ id }) => taskCategoryId === id);
 
   const toggleDatePicker = useCallback(
     (isOpen: boolean) => () => {
@@ -83,7 +73,7 @@ const Form = () => {
     }
 
     routineBottomSheetMethodsRef.current?.present();
-  }, [taskMode, isFormDisabled]);
+  }, [isFormDisabled]);
 
   const onSubmit = useCallback<any>((values: FormData) => {
     console.log(values);
@@ -187,7 +177,7 @@ const Form = () => {
                     <Text style={styles.optionalLabel}>(선택)</Text>
                   </View>
                   <Text style={[styles.emptyValue, taskCategoryId && styles.value]}>
-                    {prevSelectedCategory ? prevSelectedCategory.name : '미등록'}
+                    {prevSelectedCategory ? prevSelectedCategory.title : '미등록'}
                   </Text>
                 </Pressable>
               )}

--- a/src/constants/queries/index.ts
+++ b/src/constants/queries/index.ts
@@ -8,4 +8,8 @@ const MEMBER_QUERY_KEY = {
   SIGN_UP: ['member', 'signup'],
 } as const;
 
-export { AUTH_QUERY_KEY, MEMBER_QUERY_KEY };
+const TASK_QUERY_KEY = {
+  CATEGORY_LIST: ['task', 'category', 'list'],
+} as const;
+
+export { AUTH_QUERY_KEY, MEMBER_QUERY_KEY, TASK_QUERY_KEY };

--- a/src/hooks/queries/task/useFetchTaskCategoryList.ts
+++ b/src/hooks/queries/task/useFetchTaskCategoryList.ts
@@ -1,0 +1,15 @@
+import { AxiosError } from 'axios';
+import { useQuery } from '@tanstack/react-query';
+
+import { TASK_QUERY_KEY } from 'constants/queries';
+import { fetchTaskCategoryList } from 'services/rest/task';
+import type { fetchTaskCategoryListResponseSchemeType, taskCategorySchemeType } from 'types/task/scheme/api';
+
+const useFetchTaskCategoryList = () =>
+  useQuery<fetchTaskCategoryListResponseSchemeType, AxiosError, taskCategorySchemeType[]>({
+    queryKey: TASK_QUERY_KEY.CATEGORY_LIST,
+    queryFn: () => fetchTaskCategoryList(),
+    select: data => data.data,
+  });
+
+export { useFetchTaskCategoryList };

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+import { BaseResponseScheme } from 'schemes/shared/api';
+import { CREATION_TYPE_ENUM } from 'schemes/task/enum';
+
+const taskCategoryScheme = z.object({
+  id: z.number().describe('조회한 Task Category의 id'),
+  title: z.string().describe('Task Category의 이름'),
+  creationType: CREATION_TYPE_ENUM.describe('Task Category의 타입 (공통 / 유저 개인)'),
+  emoji: z.string().describe('Task Category 표시 이모티콘'),
+  categoryHolderId: z.string().describe('유저 생성 Category 인 경우 생성한 member의 id'),
+});
+
+const fetchTaskCategoryListResponseScheme = BaseResponseScheme.extend({
+  data: z.array(taskCategoryScheme),
+});
+
+export { taskCategoryScheme, fetchTaskCategoryListResponseScheme };

--- a/src/schemes/task/enum.ts
+++ b/src/schemes/task/enum.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+const CREATION_TYPE_ENUM = z.enum(['COMMON', 'USER_CUSTOM']);
+
+export { CREATION_TYPE_ENUM };

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -1,0 +1,14 @@
+import { apiClient } from 'services/apiClient';
+import { TASK_API } from 'services/urls';
+import type { fetchTaskCategoryListResponseSchemeType } from 'types/task/scheme/api';
+
+const fetchTaskCategoryList = async (): Promise<fetchTaskCategoryListResponseSchemeType> => {
+  try {
+    const result = await apiClient.get<fetchTaskCategoryListResponseSchemeType>(TASK_API.CATEGORY_LIST);
+    return result.data;
+  } catch (e) {
+    throw e;
+  }
+};
+
+export { fetchTaskCategoryList };

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -8,4 +8,8 @@ const MEMBER_API = {
   SIGN_UP: 'v1/member',
 } as const;
 
-export { AUTH_API, MEMBER_API };
+const TASK_API = {
+  CATEGORY_LIST: 'v1/tasks/category',
+} as const;
+
+export { AUTH_API, MEMBER_API, TASK_API };

--- a/src/types/task/scheme/api.ts
+++ b/src/types/task/scheme/api.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+import { fetchTaskCategoryListResponseScheme, taskCategoryScheme } from 'schemes/task/api';
+
+type taskCategorySchemeType = z.infer<typeof taskCategoryScheme>;
+type fetchTaskCategoryListResponseSchemeType = z.infer<typeof fetchTaskCategoryListResponseScheme>;
+
+export type { taskCategorySchemeType, fetchTaskCategoryListResponseSchemeType };


### PR DESCRIPTION
## 🤔 개요
테스크 카테고리 api를 연동해야 함

## 📝 작업 내용
테스크 카테고리 api를 연동

## 📸 작업 화면
<table>
<tr>
<td>🤖 AOS</td>
<td>🍎 IOS</td>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/bbd45298-5459-44dc-a13e-e04ba58a24a9
</td>
<td>

https://github.com/user-attachments/assets/9740eeb6-e481-4e51-809f-1d4736a52872
</td>
</tr>
</table>


## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-392](https://www.notion.so/Task-API-1f7df3a3e43f805f8998ef890895ba6f?source=copy_link)