### PR TITLE
[TAS-402]add: 회원탈퇴 API 연동 및 일부 인증 로직 관련 코드 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -47,7 +47,7 @@ function AppContent() {
     setIsLoggedIn,
     setIsNeedRefreshToken,
     setIsNeedSignUp,
-    removeTokenInfo,
+    initAuthInfo,
   } = useAuthStore(
     ({
       tokenInfo,
@@ -55,7 +55,7 @@ function AppContent() {
       isLoggedIn,
       isNeedSignUp,
       isHydrated,
-      actions: { setTokenInfo, setIsLoggedIn, setIsNeedRefreshToken, setIsNeedSignUp, removeTokenInfo },
+      actions: { setTokenInfo, setIsLoggedIn, setIsNeedRefreshToken, setIsNeedSignUp, initAuthInfo },
     }) => ({
       tokenInfo,
       isNeedRefreshToken,
@@ -66,7 +66,7 @@ function AppContent() {
       setIsLoggedIn,
       setIsNeedRefreshToken,
       setIsNeedSignUp,
-      removeTokenInfo,
+      initAuthInfo,
     }),
   );
 
@@ -135,7 +135,7 @@ function AppContent() {
   ]);
 
   // useEffect(() => {
-  //   removeTokenInfo();
+  //   initAuthInfo();
   // }, []);
 
   return (

--- a/src/constants/queries/index.ts
+++ b/src/constants/queries/index.ts
@@ -6,6 +6,7 @@ const AUTH_QUERY_KEY = {
 const MEMBER_QUERY_KEY = {
   VALID_NICKNAME: ['member', 'valid', 'nickname'],
   SIGN_UP: ['member', 'signup'],
+  DELETE_ACCOUNT: ['member', 'delete'],
 } as const;
 
 const TASK_QUERY_KEY = {

--- a/src/hooks/queries/auth/useFetchTokenQuery.ts
+++ b/src/hooks/queries/auth/useFetchTokenQuery.ts
@@ -33,7 +33,7 @@ const useFetchTokenQuery = () => {
         return;
       }
 
-      if (!data.atk || !data.rtk) {
+      if (!data.atk || !data.rtk || !data.memberId) {
         return;
       }
 

--- a/src/hooks/queries/auth/useRefreshTokenQuery.ts
+++ b/src/hooks/queries/auth/useRefreshTokenQuery.ts
@@ -11,12 +11,13 @@ import { useAuthStore } from 'stores/auth';
  * 토큰 재발급 Mutation Query Hook
  */
 const useRefreshTokenQuery = () => {
-  const { setTokenInfo, setIsNeedSignUp, setIsLoggedIn, setIsNeedRefreshToken } = useAuthStore(
-    ({ actions: { setTokenInfo, setIsNeedSignUp, setIsLoggedIn, setIsNeedRefreshToken } }) => ({
+  const { setTokenInfo, setIsNeedSignUp, setIsLoggedIn, setIsNeedRefreshToken, setMemberId } = useAuthStore(
+    ({ actions: { setTokenInfo, setIsNeedSignUp, setIsLoggedIn, setIsNeedRefreshToken, setMemberId } }) => ({
       setTokenInfo,
       setIsNeedSignUp,
       setIsLoggedIn,
       setIsNeedRefreshToken,
+      setMemberId,
     }),
   );
 
@@ -24,7 +25,7 @@ const useRefreshTokenQuery = () => {
     mutationKey: AUTH_QUERY_KEY.REFRESH_TOKEN,
     mutationFn: payload => refreshToken(payload),
     onSuccess: ({ data }) => {
-      if (!data.atk || !data.rtk) {
+      if (!data.atk || !data.rtk || !data.memberId) {
         return;
       }
 
@@ -33,6 +34,7 @@ const useRefreshTokenQuery = () => {
       setIsLoggedIn(true);
       setIsNeedRefreshToken(false);
       setIsNeedSignUp(false);
+      setMemberId(data.memberId);
     },
     onError: e => {
       console.error('토큰 재발급 실패 ', e.response?.data);

--- a/src/hooks/queries/member/useDeleteAccount.ts
+++ b/src/hooks/queries/member/useDeleteAccount.ts
@@ -4,7 +4,9 @@ import { AxiosError } from 'axios';
 
 import { deleteAccount } from 'services/rest/member';
 import { MEMBER_QUERY_KEY } from 'constants/queries';
-import { useAuthStore } from 'stores/auth';
+import { INITIAL_STORAGE_VALUE, useAuthStore } from 'stores/auth';
+import { secureStorage, STORAGE_KEY } from 'stores/secure';
+import type { deleteAccountResponseSchemeType } from 'types/member/scheme/api';
 
 const useDeleteAccount = () => {
   const { setIsLoggedIn, setTokenInfo, setMemberId } = useAuthStore(
@@ -15,15 +17,21 @@ const useDeleteAccount = () => {
     }),
   );
 
-  return useMutation<any, AxiosError, any>({
+  return useMutation<deleteAccountResponseSchemeType, AxiosError, { memberId: string }>({
     mutationKey: MEMBER_QUERY_KEY.DELETE_ACCOUNT,
     mutationFn: payload => deleteAccount(payload),
-    onSuccess: ({ data }) => {
+    onSuccess: async ({ data }) => {
       console.log('delete success data: ', data);
       setIsLoggedIn(false);
       setTokenInfo({ access: null, refresh: null });
       setMemberId(null);
-      // TODO: 스토리지 초기화 필요
+
+      try {
+        await secureStorage().setItem(STORAGE_KEY.AUTH_INFO, JSON.stringify(INITIAL_STORAGE_VALUE));
+      } catch (e) {
+        Alert.alert('스토리지 초기화에 실패했습니다.');
+        throw e;
+      }
     },
     onError: e => {
       console.error('회원탈퇴 실패 ', e.response?.data);

--- a/src/hooks/queries/member/useDeleteAccount.ts
+++ b/src/hooks/queries/member/useDeleteAccount.ts
@@ -8,24 +8,16 @@ import { useAuthStore } from 'stores/auth';
 import type { deleteAccountResponseSchemeType } from 'types/member/scheme/api';
 
 const useDeleteAccount = () => {
-  const { setIsLoggedIn, setTokenInfo, setMemberId, removeTokenInfo } = useAuthStore(
-    ({ actions: { setIsLoggedIn, setTokenInfo, setMemberId, removeTokenInfo } }) => ({
-      setIsLoggedIn,
-      setTokenInfo,
-      setMemberId,
-      removeTokenInfo,
-    }),
-  );
+  const { initAuthInfo } = useAuthStore(({ actions: { initAuthInfo } }) => ({
+    initAuthInfo,
+  }));
 
   return useMutation<deleteAccountResponseSchemeType, AxiosError, { memberId: string }>({
     mutationKey: MEMBER_QUERY_KEY.DELETE_ACCOUNT,
     mutationFn: payload => deleteAccount(payload),
     onSuccess: async ({ data }) => {
       console.log('delete success data: ', data);
-      removeTokenInfo();
-      setIsLoggedIn(false);
-      setTokenInfo({ access: null, refresh: null });
-      setMemberId(null);
+      initAuthInfo();
     },
     onError: e => {
       console.error('회원탈퇴 실패 ', e.response?.data);

--- a/src/hooks/queries/member/useDeleteAccount.ts
+++ b/src/hooks/queries/member/useDeleteAccount.ts
@@ -4,16 +4,16 @@ import { AxiosError } from 'axios';
 
 import { deleteAccount } from 'services/rest/member';
 import { MEMBER_QUERY_KEY } from 'constants/queries';
-import { INITIAL_STORAGE_VALUE, useAuthStore } from 'stores/auth';
-import { secureStorage, STORAGE_KEY } from 'stores/secure';
+import { useAuthStore } from 'stores/auth';
 import type { deleteAccountResponseSchemeType } from 'types/member/scheme/api';
 
 const useDeleteAccount = () => {
-  const { setIsLoggedIn, setTokenInfo, setMemberId } = useAuthStore(
-    ({ actions: { setIsLoggedIn, setTokenInfo, setMemberId } }) => ({
+  const { setIsLoggedIn, setTokenInfo, setMemberId, removeTokenInfo } = useAuthStore(
+    ({ actions: { setIsLoggedIn, setTokenInfo, setMemberId, removeTokenInfo } }) => ({
       setIsLoggedIn,
       setTokenInfo,
       setMemberId,
+      removeTokenInfo,
     }),
   );
 
@@ -22,16 +22,10 @@ const useDeleteAccount = () => {
     mutationFn: payload => deleteAccount(payload),
     onSuccess: async ({ data }) => {
       console.log('delete success data: ', data);
+      removeTokenInfo();
       setIsLoggedIn(false);
       setTokenInfo({ access: null, refresh: null });
       setMemberId(null);
-
-      try {
-        await secureStorage().setItem(STORAGE_KEY.AUTH_INFO, JSON.stringify(INITIAL_STORAGE_VALUE));
-      } catch (e) {
-        Alert.alert('스토리지 초기화에 실패했습니다.');
-        throw e;
-      }
     },
     onError: e => {
       console.error('회원탈퇴 실패 ', e.response?.data);

--- a/src/hooks/queries/member/useDeleteAccount.ts
+++ b/src/hooks/queries/member/useDeleteAccount.ts
@@ -1,0 +1,35 @@
+import { Alert } from 'react-native';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { deleteAccount } from 'services/rest/member';
+import { MEMBER_QUERY_KEY } from 'constants/queries';
+import { useAuthStore } from 'stores/auth';
+
+const useDeleteAccount = () => {
+  const { setIsLoggedIn, setTokenInfo, setMemberId } = useAuthStore(
+    ({ actions: { setIsLoggedIn, setTokenInfo, setMemberId } }) => ({
+      setIsLoggedIn,
+      setTokenInfo,
+      setMemberId,
+    }),
+  );
+
+  return useMutation<any, AxiosError, any>({
+    mutationKey: MEMBER_QUERY_KEY.DELETE_ACCOUNT,
+    mutationFn: payload => deleteAccount(payload),
+    onSuccess: ({ data }) => {
+      console.log('delete success data: ', data);
+      setIsLoggedIn(false);
+      setTokenInfo({ access: null, refresh: null });
+      setMemberId(null);
+      // TODO: 스토리지 초기화 필요
+    },
+    onError: e => {
+      console.error('회원탈퇴 실패 ', e.response?.data);
+      Alert.alert('회원탈퇴에 실패했습니다.');
+    },
+  });
+};
+
+export { useDeleteAccount };

--- a/src/schemes/auth/api.ts
+++ b/src/schemes/auth/api.ts
@@ -30,6 +30,7 @@ const refreshTokenResponseScheme = BaseResponseScheme.extend({
   data: z.object({
     atk: tokenScheme,
     rtk: tokenScheme,
+    memberId: z.string(),
   }),
 });
 

--- a/src/schemes/member/api.ts
+++ b/src/schemes/member/api.ts
@@ -24,4 +24,14 @@ const signUpRequestScheme = z.object({
 
 const signUpResponseScheme = fetchTokenResponseScheme;
 
-export { validNicknameRequestScheme, validNicknameResponseScheme, signUpRequestScheme, signUpResponseScheme };
+const deleteAccountResponseScheme = BaseResponseScheme.extend({
+  data: z.object({}),
+});
+
+export {
+  validNicknameRequestScheme,
+  validNicknameResponseScheme,
+  signUpRequestScheme,
+  signUpResponseScheme,
+  deleteAccountResponseScheme,
+};

--- a/src/screens/Mypage/Setting/Myinfo/index.tsx
+++ b/src/screens/Mypage/Setting/Myinfo/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Dimensions, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Alert, Dimensions, Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { Controller, useForm } from 'react-hook-form';
 import { HelperText, IconButton, TextInput } from 'react-native-paper';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
@@ -13,7 +13,8 @@ import { ConfirmModal } from 'components/common/Modal';
 import { DELETE_ACCOUNT_CONFIRM_MODAL_CONTENT, LOGOUT_CONFIRM_MODAL_CONTENT } from 'constants/Mypage';
 import type { SettingStackScreenProps } from 'types/shared';
 import { useDeleteAccount } from 'hooks/queries/member/useDeleteAccount';
-import { useAuthStore } from 'stores/auth';
+import { INITIAL_STORAGE_VALUE, useAuthStore } from 'stores/auth';
+import { secureStorage, STORAGE_KEY } from 'stores/secure';
 
 type FormData = {
   nickname: string;
@@ -61,21 +62,27 @@ const Myinfo = ({ navigation: { navigate } }: SettingStackScreenProps<'MYINFO'>)
     setModalType('DELETE_ACCOUNT');
   }, [toggleModalOpen]);
 
-  const onPressConfirmButton = useCallback(() => {
+  const onPressConfirmButton = useCallback(async () => {
     toggleModalOpen();
 
     if (modalType === 'LOGOUT') {
       setIsLoggedIn(false);
       setTokenInfo({ access: null, refresh: null });
       setMemberId(null);
-      // TODO: 스토리지 초기화 필요
+
+      try {
+        await secureStorage().setItem(STORAGE_KEY.AUTH_INFO, JSON.stringify(INITIAL_STORAGE_VALUE));
+      } catch (e) {
+        Alert.alert('스토리지 초기화에 실패했습니다.');
+        throw e;
+      }
     }
   }, [modalType, setIsLoggedIn, setMemberId, setTokenInfo, toggleModalOpen]);
 
   const onPressCancelButton = useCallback(() => {
     toggleModalOpen();
 
-    if (modalType === 'DELETE_ACCOUNT') {
+    if (modalType === 'DELETE_ACCOUNT' && memberId) {
       mutateDeleteAccount({ memberId });
       return;
     }

--- a/src/screens/Mypage/Setting/Myinfo/index.tsx
+++ b/src/screens/Mypage/Setting/Myinfo/index.tsx
@@ -13,8 +13,7 @@ import { ConfirmModal } from 'components/common/Modal';
 import { DELETE_ACCOUNT_CONFIRM_MODAL_CONTENT, LOGOUT_CONFIRM_MODAL_CONTENT } from 'constants/Mypage';
 import type { SettingStackScreenProps } from 'types/shared';
 import { useDeleteAccount } from 'hooks/queries/member/useDeleteAccount';
-import { INITIAL_STORAGE_VALUE, useAuthStore } from 'stores/auth';
-import { secureStorage, STORAGE_KEY } from 'stores/secure';
+import { useAuthStore } from 'stores/auth';
 
 type FormData = {
   nickname: string;
@@ -22,12 +21,13 @@ type FormData = {
 };
 
 const Myinfo = ({ navigation: { navigate } }: SettingStackScreenProps<'MYINFO'>) => {
-  const { memberId, setTokenInfo, setIsLoggedIn, setMemberId } = useAuthStore(
-    ({ memberId, actions: { setTokenInfo, setIsLoggedIn, setMemberId } }) => ({
+  const { memberId, setTokenInfo, setIsLoggedIn, setMemberId, removeTokenInfo } = useAuthStore(
+    ({ memberId, actions: { setTokenInfo, setIsLoggedIn, setMemberId, removeTokenInfo } }) => ({
       memberId,
       setTokenInfo,
       setIsLoggedIn,
       setMemberId,
+      removeTokenInfo,
     }),
   );
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -66,16 +66,10 @@ const Myinfo = ({ navigation: { navigate } }: SettingStackScreenProps<'MYINFO'>)
     toggleModalOpen();
 
     if (modalType === 'LOGOUT') {
+      removeTokenInfo();
       setIsLoggedIn(false);
       setTokenInfo({ access: null, refresh: null });
       setMemberId(null);
-
-      try {
-        await secureStorage().setItem(STORAGE_KEY.AUTH_INFO, JSON.stringify(INITIAL_STORAGE_VALUE));
-      } catch (e) {
-        Alert.alert('스토리지 초기화에 실패했습니다.');
-        throw e;
-      }
     }
   }, [modalType, setIsLoggedIn, setMemberId, setTokenInfo, toggleModalOpen]);
 

--- a/src/screens/Mypage/Setting/Myinfo/index.tsx
+++ b/src/screens/Mypage/Setting/Myinfo/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Alert, Dimensions, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Dimensions, Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { Controller, useForm } from 'react-hook-form';
 import { HelperText, IconButton, TextInput } from 'react-native-paper';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
@@ -21,15 +21,10 @@ type FormData = {
 };
 
 const Myinfo = ({ navigation: { navigate } }: SettingStackScreenProps<'MYINFO'>) => {
-  const { memberId, setTokenInfo, setIsLoggedIn, setMemberId, removeTokenInfo } = useAuthStore(
-    ({ memberId, actions: { setTokenInfo, setIsLoggedIn, setMemberId, removeTokenInfo } }) => ({
-      memberId,
-      setTokenInfo,
-      setIsLoggedIn,
-      setMemberId,
-      removeTokenInfo,
-    }),
-  );
+  const { memberId, initAuthInfo } = useAuthStore(({ memberId, actions: { initAuthInfo } }) => ({
+    memberId,
+    initAuthInfo,
+  }));
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalType, setModalType] = useState<'LOGOUT' | 'DELETE_ACCOUNT' | null>(null);
   const { mutate: mutateDeleteAccount } = useDeleteAccount();
@@ -66,12 +61,9 @@ const Myinfo = ({ navigation: { navigate } }: SettingStackScreenProps<'MYINFO'>)
     toggleModalOpen();
 
     if (modalType === 'LOGOUT') {
-      removeTokenInfo();
-      setIsLoggedIn(false);
-      setTokenInfo({ access: null, refresh: null });
-      setMemberId(null);
+      initAuthInfo();
     }
-  }, [modalType, setIsLoggedIn, setMemberId, setTokenInfo, toggleModalOpen]);
+  }, [modalType, toggleModalOpen]);
 
   const onPressCancelButton = useCallback(() => {
     toggleModalOpen();

--- a/src/screens/Mypage/Setting/Myinfo/index.tsx
+++ b/src/screens/Mypage/Setting/Myinfo/index.tsx
@@ -12,6 +12,8 @@ import { BasicMenu } from 'components/Mypage/Setting/Menu';
 import { ConfirmModal } from 'components/common/Modal';
 import { DELETE_ACCOUNT_CONFIRM_MODAL_CONTENT, LOGOUT_CONFIRM_MODAL_CONTENT } from 'constants/Mypage';
 import type { SettingStackScreenProps } from 'types/shared';
+import { useDeleteAccount } from 'hooks/queries/member/useDeleteAccount';
+import { useAuthStore } from 'stores/auth';
 
 type FormData = {
   nickname: string;
@@ -19,8 +21,17 @@ type FormData = {
 };
 
 const Myinfo = ({ navigation: { navigate } }: SettingStackScreenProps<'MYINFO'>) => {
+  const { memberId, setTokenInfo, setIsLoggedIn, setMemberId } = useAuthStore(
+    ({ memberId, actions: { setTokenInfo, setIsLoggedIn, setMemberId } }) => ({
+      memberId,
+      setTokenInfo,
+      setIsLoggedIn,
+      setMemberId,
+    }),
+  );
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalType, setModalType] = useState<'LOGOUT' | 'DELETE_ACCOUNT' | null>(null);
+  const { mutate: mutateDeleteAccount } = useDeleteAccount();
 
   const {
     watch,
@@ -53,22 +64,22 @@ const Myinfo = ({ navigation: { navigate } }: SettingStackScreenProps<'MYINFO'>)
   const onPressConfirmButton = useCallback(() => {
     toggleModalOpen();
 
-    if (modalType === 'DELETE_ACCOUNT') {
-      return;
+    if (modalType === 'LOGOUT') {
+      setIsLoggedIn(false);
+      setTokenInfo({ access: null, refresh: null });
+      setMemberId(null);
+      // TODO: 스토리지 초기화 필요
     }
-
-    // TODO: 로그아웃 API 연동
-  }, [modalType, toggleModalOpen]);
+  }, [modalType, setIsLoggedIn, setMemberId, setTokenInfo, toggleModalOpen]);
 
   const onPressCancelButton = useCallback(() => {
     toggleModalOpen();
 
-    if (modalType === 'LOGOUT') {
+    if (modalType === 'DELETE_ACCOUNT') {
+      mutateDeleteAccount({ memberId });
       return;
     }
-
-    // TODO: 회원 탈퇴 API 연동
-  }, [modalType, toggleModalOpen]);
+  }, [memberId, modalType, mutateDeleteAccount, toggleModalOpen]);
 
   const onSubmit = useCallback((values: FormData) => {
     console.log(values);

--- a/src/services/rest/member.ts
+++ b/src/services/rest/member.ts
@@ -26,11 +26,9 @@ const signUp = async (payload: signUpRequestSchemeType): Promise<signUpResponseS
   }
 };
 
-const deleteAccount = async (memberId: string): Promise<deleteAccountResponseSchemeType> => {
+const deleteAccount = async ({ memberId }: { memberId: string }): Promise<deleteAccountResponseSchemeType> => {
   try {
-    const result = await apiClient.delete<deleteAccountResponseSchemeType>(MEMBER_API.DELETE_ACCOUNT, {
-      params: { memberId },
-    });
+    const result = await apiClient.delete<deleteAccountResponseSchemeType>(`${MEMBER_API.DELETE_ACCOUNT}/${memberId}`);
     return result.data;
   } catch (e) {
     throw e;

--- a/src/services/rest/member.ts
+++ b/src/services/rest/member.ts
@@ -1,6 +1,7 @@
 import { MEMBER_API } from 'services/urls';
 import { apiClient } from 'services/apiClient';
 import type {
+  deleteAccountResponseSchemeType,
   signUpRequestSchemeType,
   signUpResponseSchemeType,
   validNicknameRequestSchemeType,
@@ -25,4 +26,15 @@ const signUp = async (payload: signUpRequestSchemeType): Promise<signUpResponseS
   }
 };
 
-export { validNickname, signUp };
+const deleteAccount = async (memberId: string): Promise<deleteAccountResponseSchemeType> => {
+  try {
+    const result = await apiClient.delete<deleteAccountResponseSchemeType>(MEMBER_API.DELETE_ACCOUNT, {
+      params: { memberId },
+    });
+    return result.data;
+  } catch (e) {
+    throw e;
+  }
+};
+
+export { validNickname, signUp, deleteAccount };

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -6,6 +6,7 @@ const AUTH_API = {
 const MEMBER_API = {
   VALID_NICKNAME: 'v1/members/nickname',
   SIGN_UP: 'v1/members',
+  DELETE_ACCOUNT: 'v1/members',
 } as const;
 
 const TASK_API = {

--- a/src/stores/auth/index.ts
+++ b/src/stores/auth/index.ts
@@ -26,7 +26,7 @@ type State = {
 type Action = {
   setTokenInfo: (token: Partial<State['tokenInfo']>) => void;
   setMemberId: (id: State['memberId']) => void;
-  removeTokenInfo: () => void;
+  initAuthInfo: () => void;
   setIsLoggedIn: (value: boolean) => void;
   setIsNeedSignUp: (value: boolean) => void;
   setIsNeedRefreshToken: (value: boolean) => void;
@@ -63,10 +63,10 @@ const useAuthStore = create<State & { actions: Action }>()(
         setTokenInfo: info => {
           set({ tokenInfo: { ...get().tokenInfo, ...info } });
         },
-        removeTokenInfo: async () => {
+        initAuthInfo: async () => {
           try {
             await secureStorage().setItem(STORAGE_KEY.AUTH_INFO, JSON.stringify(INITIAL_STORAGE_VALUE));
-            set(initialState);
+            set({ ...initialState, isHydrated: true });
           } catch (error) {
             console.error('토큰 정보 삭제에 실패했습니다.', error);
           }
@@ -93,15 +93,7 @@ const useAuthStore = create<State & { actions: Action }>()(
 
         const {
           tokenInfo,
-          actions: {
-            setIsLoggedIn,
-            setIsNeedSignUp,
-            setIsNeedRefreshToken,
-            setTokenInfo,
-            setMemberId,
-            removeTokenInfo,
-            setIsHydrated,
-          },
+          actions: { setIsLoggedIn, setIsNeedSignUp, setIsNeedRefreshToken, setTokenInfo, initAuthInfo, setIsHydrated },
         } = mergedState;
 
         try {
@@ -137,13 +129,7 @@ const useAuthStore = create<State & { actions: Action }>()(
               }
 
               // refresh 토큰이 만료되었을 경우 인증 정보 상태 및 스토리지 초기화
-              removeTokenInfo();
-              setMemberId(null);
-              setTokenInfo({
-                signup: null,
-                access: null,
-                refresh: null,
-              });
+              initAuthInfo();
             }
           }
 

--- a/src/stores/auth/index.ts
+++ b/src/stores/auth/index.ts
@@ -65,7 +65,7 @@ const useAuthStore = create<State & { actions: Action }>()(
         },
         removeTokenInfo: async () => {
           try {
-            await EncryptedStorage.removeItem(STORAGE_KEY.AUTH_INFO);
+            await secureStorage().setItem(STORAGE_KEY.AUTH_INFO, JSON.stringify(INITIAL_STORAGE_VALUE));
             set(initialState);
           } catch (error) {
             console.error('토큰 정보 삭제에 실패했습니다.', error);

--- a/src/stores/auth/index.ts
+++ b/src/stores/auth/index.ts
@@ -33,13 +33,17 @@ type Action = {
   setIsHydrated: (value: boolean) => void;
 };
 
-const initialState = {
+const INITIAL_STORAGE_VALUE = {
   tokenInfo: {
     signup: null,
     access: null,
     refresh: null,
   },
   memberId: null,
+};
+
+const initialState = {
+  ...INITIAL_STORAGE_VALUE,
   isLoggedIn: false,
   isNeedSignUp: false,
   isNeedRefreshToken: false,
@@ -61,7 +65,7 @@ const useAuthStore = create<State & { actions: Action }>()(
         },
         removeTokenInfo: async () => {
           try {
-            await EncryptedStorage.removeItem(STORAGE_KEY.TOKEN_INFO);
+            await EncryptedStorage.removeItem(STORAGE_KEY.AUTH_INFO);
             set(initialState);
           } catch (error) {
             console.error('토큰 정보 삭제에 실패했습니다.', error);
@@ -70,7 +74,7 @@ const useAuthStore = create<State & { actions: Action }>()(
       },
     }),
     {
-      name: STORAGE_KEY.TOKEN_INFO,
+      name: STORAGE_KEY.AUTH_INFO,
       storage: createJSONStorage(secureStorage),
       partialize: ({ tokenInfo, memberId }) => ({
         tokenInfo,
@@ -152,4 +156,4 @@ const useAuthStore = create<State & { actions: Action }>()(
   ),
 );
 
-export { useAuthStore };
+export { useAuthStore, INITIAL_STORAGE_VALUE };

--- a/src/stores/secure/index.ts
+++ b/src/stores/secure/index.ts
@@ -1,7 +1,7 @@
 import EncryptedStorage from 'react-native-encrypted-storage';
 
 const STORAGE_KEY = {
-  TOKEN_INFO: 'TOKEN_INFO',
+  AUTH_INFO: 'AUTH_INFO',
 };
 
 type StorageKey = keyof typeof STORAGE_KEY;

--- a/src/types/member/scheme/api.ts
+++ b/src/types/member/scheme/api.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import {
+  deleteAccountResponseScheme,
   signUpRequestScheme,
   signUpResponseScheme,
   validNicknameRequestScheme,
@@ -11,10 +12,12 @@ type validNicknameRequestSchemeType = z.infer<typeof validNicknameRequestScheme>
 type validNicknameResponseSchemeType = z.infer<typeof validNicknameResponseScheme>;
 type signUpRequestSchemeType = z.infer<typeof signUpRequestScheme>;
 type signUpResponseSchemeType = z.infer<typeof signUpResponseScheme>;
+type deleteAccountResponseSchemeType = z.infer<typeof deleteAccountResponseScheme>;
 
 export type {
   validNicknameRequestSchemeType,
   validNicknameResponseSchemeType,
   signUpRequestSchemeType,
   signUpResponseSchemeType,
+  deleteAccountResponseSchemeType,
 };


### PR DESCRIPTION
## 🤔 개요
회원탈퇴 API 연동 및 일부 인증 로직 관련 코드 수정을 해야 함

## 📝 작업 내용
1. 회원탈퇴 API 연동
2. 토큰 재발급 응답 데이터 스키마 수정
3. 상태 및 스토리지 초기화 로직 메서드 이름 및 로직 수정

<!-- (선택)작업한 내용에 대해 달라진 화면을 스크린샷이나 동영상으로 첨부하여 보여주세요 
## 📸 작업 화면
<table>
<tr>
<td></td>
<td>AS-IS</td>
<td>TO-BE</td>
</tr>
<tr>
<td>🤖 AOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요 
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
<tr>
<td>🍎 IOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
</table>
-->

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-402](https://www.notion.so/API-209df3a3e43f8098b7cec7d9068fd66a?source=copy_link)
