### PR TITLE
[TAS-389, TAS-391]add: 투두/두윗 Task 등록 API 연동 및 토큰 refresh 관련 로직, task 관련 데이터 스키마 수정 외 일부 인증 작업

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Alert, AppState, StyleSheet, View } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -30,6 +30,22 @@ const subscribeListener = (event: QueryCacheNotifyEvent | MutationCacheNotifyEve
   if ('action' in event && event.action && event.action.type === 'error') {
     const errorData = event.action.error.response.data;
     const errorMessage = errorData.message;
+
+    const {
+      tokenInfo,
+      actions: { setIsNeedRefreshToken },
+    } = useAuthStore.getState();
+
+    // 액세스 토큰이 만료 되고, refresh 토큰이 만료되지 않았을 경우 토큰 재발급 상태로 수정
+    if (
+      tokenInfo.access?.token &&
+      dayjs().isAfter(tokenInfo.access?.expireAt) &&
+      tokenInfo.refresh?.token &&
+      dayjs().isBefore(tokenInfo.refresh?.expireAt)
+    ) {
+      setIsNeedRefreshToken(true);
+      return;
+    }
 
     if ('query' in event) {
       Alert.alert(`[QueryCacheNotifyEvent Error]: ${errorMessage}`);
@@ -83,6 +99,8 @@ function AppContent() {
     }),
   );
 
+  // 토큰 재발급 진행중 관련 flag 변수
+  const isTokenRefreshingRef = useRef(false);
   const isFetching = useIsFetching();
   const isMutating = useIsMutating();
   const isLoading = isFetching + isMutating > 0;
@@ -95,7 +113,8 @@ function AppContent() {
       return;
     }
 
-    if (isNeedRefreshToken && tokenInfo.refresh?.token) {
+    if (!isTokenRefreshingRef.current && isNeedRefreshToken && tokenInfo.refresh?.token) {
+      isTokenRefreshingRef.current = true;
       mutateRefreshToken(
         { refreshToken: tokenInfo.refresh.token },
         {
@@ -109,34 +128,23 @@ function AppContent() {
             setIsNeedRefreshToken(false);
             setIsNeedSignUp(false);
           },
+          onSettled: () => {
+            isTokenRefreshingRef.current = false;
+          },
         },
       );
     }
 
     const subscription = AppState.addEventListener('change', state => {
       if (state === 'active') {
-        // 액세스 토큰이 만료 되고, refresh 토큰이 만료되지 않았을 경우
+        // 액세스 토큰이 만료 되고, refresh 토큰이 만료되지 않았을 경우 토큰 재발급 상태로 수정
         if (
           tokenInfo.access?.token &&
           dayjs().isAfter(tokenInfo.access?.expireAt) &&
           tokenInfo.refresh?.token &&
           dayjs().isBefore(tokenInfo.refresh?.expireAt)
         ) {
-          mutateRefreshToken(
-            { refreshToken: tokenInfo.refresh.token },
-            {
-              onSuccess: ({ data }) => {
-                if (!data.accessToken || !data.refreshToken) {
-                  return;
-                }
-                // 토큰 재발급이 완료 되었을 경우
-                setTokenInfo({ access: data.accessToken, refresh: data.refreshToken });
-                setIsLoggedIn(true);
-                setIsNeedRefreshToken(false);
-                setIsNeedSignUp(false);
-              },
-            },
-          );
+          setIsNeedRefreshToken(true);
         }
       }
     });

--- a/App.tsx
+++ b/App.tsx
@@ -4,9 +4,17 @@ import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { PaperProvider } from 'react-native-paper';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
-import { QueryClient, QueryClientProvider, useIsFetching, useIsMutating } from '@tanstack/react-query';
+import {
+  MutationCacheNotifyEvent,
+  QueryCacheNotifyEvent,
+  QueryClient,
+  QueryClientProvider,
+  useIsFetching,
+  useIsMutating,
+} from '@tanstack/react-query';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import dayjs from 'dayjs';
 
 import { Login } from 'screens/Login';
 import { HomeStackNavigator } from 'components/navigators/Stack/Home';
@@ -18,23 +26,28 @@ import { DialogProvider } from 'components/common/Dialog/Provider';
 import { LoadingOverlay } from 'components/common/LoadingOverlay';
 import { useRefreshTokenQuery } from 'hooks/queries/auth/useRefreshTokenQuery';
 
+const subscribeListener = (event: QueryCacheNotifyEvent | MutationCacheNotifyEvent) => {
+  if ('action' in event && event.action && event.action.type === 'error') {
+    const errorData = event.action.error.response.data;
+    const errorMessage = errorData.message;
+
+    if ('query' in event) {
+      Alert.alert(`[QueryCacheNotifyEvent Error]: ${errorMessage}`);
+      console.error('[QueryCacheNotifyEvent Error]:', errorData);
+    } else if ('mutation' in event) {
+      Alert.alert(`[MutationCacheNotifyEvent Error]: ${errorMessage}`);
+      console.error('[MutationCacheNotifyEvent Error]:', errorData);
+    } else {
+      Alert.alert(`[Unknown Event Error]: ${errorMessage}`);
+      console.error('[Unknown Event Error]:', errorData);
+    }
+  }
+};
+
 const queryClient = new QueryClient();
 // 전역 에러 핸들링(모든 쿼리/뮤테이션)
-queryClient.getQueryCache().subscribe(event => {
-  if ('action' in event && event.action && event.action.type === 'error') {
-    const errorMessage = event.action.error.response.data.message;
-    Alert.alert(`에러가 발생했습니다. ${errorMessage}`);
-    console.error('Query Error:', errorMessage);
-  }
-});
-
-queryClient.getMutationCache().subscribe(event => {
-  if ('action' in event && event.action && event.action.type === 'error') {
-    const errorMessage = event.action.error.response.data.message;
-    Alert.alert(`에러가 발생했습니다. ${errorMessage}`);
-    console.error('Mutation Error:', errorMessage);
-  }
-});
+queryClient.getQueryCache().subscribe(subscribeListener);
+queryClient.getMutationCache().subscribe(subscribeListener);
 
 function AppContent() {
   const {
@@ -87,11 +100,11 @@ function AppContent() {
         { refreshToken: tokenInfo.refresh.token },
         {
           onSuccess: ({ data }) => {
-            if (!data.atk || !data.rtk) {
+            if (!data.accessToken || !data.refreshToken) {
               return;
             }
             // 토큰 재발급이 완료 되었을 경우
-            setTokenInfo({ access: data.atk, refresh: data.rtk });
+            setTokenInfo({ access: data.accessToken, refresh: data.refreshToken });
             setIsLoggedIn(true);
             setIsNeedRefreshToken(false);
             setIsNeedSignUp(false);
@@ -102,16 +115,22 @@ function AppContent() {
 
     const subscription = AppState.addEventListener('change', state => {
       if (state === 'active') {
-        if (isNeedRefreshToken && tokenInfo.refresh?.token) {
+        // 액세스 토큰이 만료 되고, refresh 토큰이 만료되지 않았을 경우
+        if (
+          tokenInfo.access?.token &&
+          dayjs().isAfter(tokenInfo.access?.expireAt) &&
+          tokenInfo.refresh?.token &&
+          dayjs().isBefore(tokenInfo.refresh?.expireAt)
+        ) {
           mutateRefreshToken(
             { refreshToken: tokenInfo.refresh.token },
             {
               onSuccess: ({ data }) => {
-                if (!data.atk || !data.rtk) {
+                if (!data.accessToken || !data.refreshToken) {
                   return;
                 }
                 // 토큰 재발급이 완료 되었을 경우
-                setTokenInfo({ access: data.atk, refresh: data.rtk });
+                setTokenInfo({ access: data.accessToken, refresh: data.refreshToken });
                 setIsLoggedIn(true);
                 setIsNeedRefreshToken(false);
                 setIsNeedSignUp(false);

--- a/src/components/Task/BottomSheet/CategoryBottomSheet/index.tsx
+++ b/src/components/Task/BottomSheet/CategoryBottomSheet/index.tsx
@@ -10,7 +10,7 @@ import { useFetchTaskCategoryList } from 'hooks/queries/task/useFetchTaskCategor
 type TaskCategory = { id: number; title: string };
 
 interface Props {
-  taskCategoryId: number;
+  taskCategoryId: number | null;
   prevSelectedCategory?: TaskCategory;
 }
 

--- a/src/components/Task/BottomSheet/RoutineBottomSheet/index.tsx
+++ b/src/components/Task/BottomSheet/RoutineBottomSheet/index.tsx
@@ -6,6 +6,7 @@ import { Calendar } from 'react-native-calendars';
 import type { MarkedDates } from 'react-native-calendars/src/types';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { useFormContext } from 'react-hook-form';
 
 import { theme } from 'styles/theme';
 import { BottomSheet } from 'components/common/BottomSheet';
@@ -29,6 +30,7 @@ interface Props {
 }
 
 const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMode }, ref) => {
+  const { setValue, watch } = useFormContext();
   const innerRef = useRef<BottomSheetModalMethods>(null);
   const todayDateString = dayjs().format('YYYY-MM-DD');
   // 투두 모드에서 사용하는 선택 기간 상태
@@ -37,16 +39,32 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
   // 두윗 모드에서 사용하는 선택한 일자들 상태
   const [selectedDateSet, setSelectedDateSet] = useState<Set<string>>(new Set());
   const [selectedPrimaryCategory, setSelectedPrimaryCategory] = useState<'DAILY' | 'WEEKLY' | 'MONTHLY' | null>(null);
-  const [selectedWeeklyDaySet, setSelectedWeeklyDaySet] = useState<
-    Set<'SUNDAY' | 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY'>
-  >(new Set());
+  const [selectedWeeklyDaySet, setSelectedWeeklyDaySet] = useState<Set<number>>(new Set());
   const [selectedMonthlyDaySet, setSelectedMonthlyDaySet] = useState<Set<number>>(new Set());
   const [expanded, setExpanded] = useState(true);
   const [isExcludeHolidays, setIsExcludeHolidays] = useState(false);
 
   const isTodoMode = taskMode === 'TODO';
-  const isValidDatePeriod = selectedStartDate && selectedEndDate;
+  const isValidDatePeriod = selectedStartDate !== null && selectedEndDate !== null;
   const isValidDateSet = selectedDateSet.size > 0;
+  const routineCondition = watch('routineCondition');
+
+  // 등록한 루틴이 유효한지 검사하는 함수 (루틴 기간, 반복 패턴을 종류에 맞게 설정했는지)
+  const isValidRoutineCondition = () => {
+    if (!isValidDatePeriod) {
+      return false;
+    }
+
+    if (selectedPrimaryCategory === 'DAILY') {
+      return true;
+    }
+
+    if (selectedPrimaryCategory === 'WEEKLY') {
+      return selectedWeeklyDaySet.size > 0;
+    }
+
+    return selectedMonthlyDaySet.size > 0;
+  };
 
   // 두윗 모드에서 사용되는 선택한 일자들 중 제일 빠른 일자와 먼 일자 반환
   const getMinMaxDate = (dateSet: Set<string>) => {
@@ -140,7 +158,7 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
 
   const handleExcludeHolidays = () => setIsExcludeHolidays(!isExcludeHolidays);
 
-  const handleDismiss = () => {
+  const initRoutineCondition = () => {
     setSelectedStartDate(null);
     setSelectedEndDate(null);
     setSelectedDateSet(new Set());
@@ -149,9 +167,99 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
     setSelectedWeeklyDaySet(new Set());
     setSelectedMonthlyDaySet(new Set());
     setExpanded(true);
+
+    setValue('routineCondition', {
+      startDate: null,
+      endDate: null,
+      cycle: null,
+      pattern: [],
+      isExcludeHolidays: false,
+    });
   };
 
-  const handleSubmit = () => {};
+  // 닫기 버튼을 눌렀을 때 이미 루틴이 설정된 경우를 제외하고 모두 초기화
+  const handleCloseButton = () => {
+    // 등록하지 않은 상태일 때
+    if (routineCondition.startDate === null || routineCondition.endDate === null || routineCondition.cycle === null) {
+      initRoutineCondition();
+      return;
+    }
+
+    // 상태 초기화가 필요한지 여부
+    let isNeedInit = true;
+
+    /*
+      값은 설정했지만 등록하기 버튼을 누르지 않았을 경우 이전 값으로 모두 롤백
+     */
+    if (routineCondition.startDate !== selectedStartDate) {
+      setSelectedStartDate(routineCondition.startDate);
+      isNeedInit = false;
+    }
+
+    if (routineCondition.endDate !== selectedEndDate) {
+      setSelectedEndDate(routineCondition.endDate);
+      isNeedInit = false;
+    }
+
+    if (routineCondition.cycle !== selectedPrimaryCategory) {
+      if (routineCondition.cycle === 'DAILY') {
+        isNeedInit = false;
+      }
+
+      if (routineCondition.cycle === 'WEEKLY') {
+        setSelectedWeeklyDaySet(new Set(routineCondition.pattern as number[]));
+        setSelectedMonthlyDaySet(new Set());
+        isNeedInit = false;
+      }
+
+      if (routineCondition.cycle === 'MONTHLY') {
+        setSelectedMonthlyDaySet(new Set(routineCondition.pattern as number[]));
+        setSelectedWeeklyDaySet(new Set());
+        isNeedInit = false;
+      }
+
+      setSelectedPrimaryCategory(routineCondition.cycle);
+    } else {
+      if (routineCondition.cycle === 'DAILY') {
+        isNeedInit = false;
+      }
+
+      if (routineCondition.cycle === 'WEEKLY' && routineCondition.pattern !== Array.from(selectedWeeklyDaySet)) {
+        setSelectedWeeklyDaySet(new Set(routineCondition.pattern as number[]));
+        isNeedInit = false;
+      }
+
+      if (routineCondition.cycle === 'MONTHLY' && routineCondition.pattern !== Array.from(selectedMonthlyDaySet)) {
+        setSelectedMonthlyDaySet(new Set(routineCondition.pattern as number[]));
+        isNeedInit = false;
+      }
+    }
+
+    if (routineCondition.isExcludeHolidays !== isExcludeHolidays) {
+      setIsExcludeHolidays(routineCondition.isExcludeHolidays);
+      isNeedInit = false;
+    }
+
+    if (isNeedInit) {
+      initRoutineCondition();
+    }
+  };
+
+  const handleSubmit = () => {
+    setValue('routineCondition.startDate', selectedStartDate);
+    setValue('routineCondition.endDate', selectedEndDate);
+    setValue('routineCondition.cycle', selectedPrimaryCategory);
+
+    if (selectedPrimaryCategory === 'DAILY') {
+      setValue('routineCondition.pattern', []);
+    } else if (selectedPrimaryCategory === 'WEEKLY') {
+      setValue('routineCondition.pattern', Array.from(selectedWeeklyDaySet));
+    } else {
+      setValue('routineCondition.pattern', Array.from(selectedMonthlyDaySet));
+    }
+
+    innerRef.current?.close();
+  };
 
   const handleExpanded = () => {
     if (expanded) {
@@ -181,9 +289,9 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
     <BottomSheet
       ref={innerRef}
       title="루틴 등록하기"
-      buttonConfig={{ title: '등록하기', isDisabled: false }}
+      buttonConfig={{ title: '등록하기', isDisabled: !isValidRoutineCondition() }}
       snapPoints={['90%']}
-      onDismiss={handleDismiss}
+      handleCloseButton={handleCloseButton}
       handleButtonSubmit={handleSubmit}
     >
       <View style={styles.container}>
@@ -294,7 +402,7 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
             </View>
             {selectedPrimaryCategory === 'WEEKLY' && (
               <View style={{ flexDirection: 'row', gap: 6 }}>
-                {WEEKLY_DAY_INFO.map(({ code, name }) => (
+                {WEEKLY_DAY_INFO.map(({ code, value, name }) => (
                   <Pressable
                     key={code}
                     style={{
@@ -303,17 +411,17 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
                       alignItems: 'center',
                       height: 38,
                       borderRadius: 8,
-                      backgroundColor: selectedWeeklyDaySet.has(code)
+                      backgroundColor: selectedWeeklyDaySet.has(value)
                         ? theme.COLORS.GRAY_SCALE.GRAY_30
                         : theme.COLORS.GRAY_SCALE.GRAY_96,
                     }}
                     onPress={() => {
                       setSelectedWeeklyDaySet(prev => {
                         const newSet = new Set(prev);
-                        if (newSet.has(code)) {
-                          newSet.delete(code);
+                        if (newSet.has(value)) {
+                          newSet.delete(value);
                         } else {
-                          newSet.add(code);
+                          newSet.add(value);
                         }
                         return newSet;
                       });
@@ -321,7 +429,9 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
                   >
                     <Text
                       style={{
-                        color: selectedWeeklyDaySet.has(code) ? theme.COLORS.DEFAULT.WHITE : theme.COLORS.DEFAULT.BLACK,
+                        color: selectedWeeklyDaySet.has(value)
+                          ? theme.COLORS.DEFAULT.WHITE
+                          : theme.COLORS.DEFAULT.BLACK,
                       }}
                     >
                       {name}

--- a/src/components/Task/BottomSheet/RoutineBottomSheet/index.tsx
+++ b/src/components/Task/BottomSheet/RoutineBottomSheet/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import type { BottomSheetModalMethods } from '@gorhom/bottom-sheet/src/types';
 import { Divider, Switch } from 'react-native-paper';
@@ -36,17 +36,13 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
   // 투두 모드에서 사용하는 선택 기간 상태
   const [selectedStartDate, setSelectedStartDate] = useState<string | null>(null);
   const [selectedEndDate, setSelectedEndDate] = useState<string | null>(null);
-  // 두윗 모드에서 사용하는 선택한 일자들 상태
-  const [selectedDateSet, setSelectedDateSet] = useState<Set<string>>(new Set());
   const [selectedPrimaryCategory, setSelectedPrimaryCategory] = useState<'DAILY' | 'WEEKLY' | 'MONTHLY' | null>(null);
   const [selectedWeeklyDaySet, setSelectedWeeklyDaySet] = useState<Set<number>>(new Set());
   const [selectedMonthlyDaySet, setSelectedMonthlyDaySet] = useState<Set<number>>(new Set());
   const [expanded, setExpanded] = useState(true);
   const [isExcludeHolidays, setIsExcludeHolidays] = useState(false);
 
-  const isTodoMode = taskMode === 'TODO';
   const isValidDatePeriod = selectedStartDate !== null && selectedEndDate !== null;
-  const isValidDateSet = selectedDateSet.size > 0;
   const routineCondition = watch('routineCondition');
 
   // 등록한 루틴이 유효한지 검사하는 함수 (루틴 기간, 반복 패턴을 종류에 맞게 설정했는지)
@@ -66,35 +62,7 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
     return selectedMonthlyDaySet.size > 0;
   };
 
-  // 두윗 모드에서 사용되는 선택한 일자들 중 제일 빠른 일자와 먼 일자 반환
-  const getMinMaxDate = (dateSet: Set<string>) => {
-    if (dateSet.size === 0) {
-      return [null, null];
-    }
-    const arr = Array.from(dateSet);
-    arr.sort(); // 문자열(YYYY-MM-DD)이면 이렇게 정렬하면 날짜순 정렬
-    return [arr[0], arr[arr.length - 1]];
-  };
-
-  // 두윗 모드에서 사용되는 선택한 일자들 마킹
-  const getMarkedDates = (selectedDates: Set<string>) => {
-    const marked: MarkedDates = {};
-    selectedDates.forEach(dateStr => {
-      marked[dateStr] = {
-        customStyles: {
-          container: {
-            backgroundColor: theme.COLORS.GRAY_SCALE.GRAY_92,
-          },
-          text: {
-            color: theme.COLORS.DEFAULT.BLACK,
-          },
-        },
-      };
-    });
-    return marked;
-  };
-
-  // 투두 모드에서 사용되는 선택한 기간 마킹
+  // 선택한 기간 마킹하는 함수
   const getMarkedPeriodDates = (start: string | null, end: string | null): MarkedDates => {
     if (!start) {
       return {};
@@ -161,7 +129,6 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
   const initRoutineCondition = () => {
     setSelectedStartDate(null);
     setSelectedEndDate(null);
-    setSelectedDateSet(new Set());
     setIsExcludeHolidays(false);
     setSelectedPrimaryCategory(null);
     setSelectedWeeklyDaySet(new Set());
@@ -283,6 +250,10 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
     setSelectedPrimaryCategory(value);
   };
 
+  useEffect(() => {
+    initRoutineCondition();
+  }, [taskMode]);
+
   useImperativeHandle(ref, () => innerRef.current!);
 
   return (
@@ -297,205 +268,161 @@ const RoutineBottomSheet = forwardRef<BottomSheetModalMethods, Props>(({ taskMod
       <View style={styles.container}>
         <View style={styles.dateSection}>
           <View style={styles.dateLeftSection}>
-            <Text style={theme.TYPOGRAPHY.SUB_TITLE}>{isTodoMode ? '반복 기간' : '선택 날짜'}</Text>
-            {isTodoMode && !isValidDatePeriod && (
+            <Text style={theme.TYPOGRAPHY.SUB_TITLE}>반복 기간</Text>
+            {!isValidDatePeriod && (
               <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_60 }]}>
                 루틴을 반복할 시작일과 종료일을 선택해주세요.
               </Text>
             )}
           </View>
-          {isTodoMode ? (
-            <Pressable style={styles.dateRightSection} onPress={handleExpanded}>
-              <Text
-                style={[
-                  theme.TYPOGRAPHY.BODY_2,
-                  {
-                    color: isValidDatePeriod ? theme.COLORS.DEFAULT.BLACK : theme.COLORS.GRAY_SCALE.GRAY_70,
-                  },
-                ]}
-              >
-                {isValidDatePeriod ? `${selectedStartDate} ~ ${selectedEndDate}` : '미선택'}
-              </Text>
-              <DropArrow direction={expanded ? 'UP' : 'DOWN'} />
-            </Pressable>
-          ) : (
-            <View style={{ alignItems: 'flex-end', gap: 4 }}>
-              {isValidDateSet && <Text style={theme.TYPOGRAPHY.BODY_2}>{selectedDateSet.size}개</Text>}
-              <Text
-                style={[
-                  theme.TYPOGRAPHY.BODY_2,
-                  {
-                    color: theme.COLORS.GRAY_SCALE.GRAY_60,
-                  },
-                ]}
-              >
-                {isValidDateSet
-                  ? selectedDateSet.size > 1
-                    ? `${getMinMaxDate(selectedDateSet)[0]} ~ ${getMinMaxDate(selectedDateSet)[1]}`
-                    : selectedDateSet
-                  : '미선택'}
-              </Text>
-            </View>
-          )}
+          <Pressable style={styles.dateRightSection} onPress={handleExpanded}>
+            <Text
+              style={[
+                theme.TYPOGRAPHY.BODY_2,
+                {
+                  color: isValidDatePeriod ? theme.COLORS.DEFAULT.BLACK : theme.COLORS.GRAY_SCALE.GRAY_70,
+                },
+              ]}
+            >
+              {isValidDatePeriod ? `${selectedStartDate} ~ ${selectedEndDate}` : '미선택'}
+            </Text>
+            <DropArrow direction={expanded ? 'UP' : 'DOWN'} />
+          </Pressable>
         </View>
         <Divider style={{ marginVertical: 20 }} />
         {expanded && (
           <Calendar
             style={{ marginBottom: 32 }}
-            markingType={isTodoMode ? 'period' : 'custom'}
-            markedDates={
-              isTodoMode ? getMarkedPeriodDates(selectedStartDate, selectedEndDate) : getMarkedDates(selectedDateSet)
-            }
+            markingType={'period'}
+            markedDates={getMarkedPeriodDates(selectedStartDate, selectedEndDate)}
             minDate={todayDateString}
             onDayPress={date => {
-              if (isTodoMode) {
-                if (!selectedStartDate) {
-                  setSelectedStartDate(date.dateString);
-                  return;
-                }
-                setSelectedEndDate(date.dateString);
+              if (!selectedStartDate) {
+                setSelectedStartDate(date.dateString);
+                return;
               }
-
-              setSelectedDateSet(prev => {
-                const newSet = new Set(prev);
-                if (newSet.has(date.dateString)) {
-                  newSet.delete(date.dateString);
-                } else {
-                  newSet.add(date.dateString);
-                }
-                return newSet;
-              });
+              setSelectedEndDate(date.dateString);
             }}
           />
         )}
-        {isTodoMode && (
-          <View style={styles.routineSection}>
-            <Text style={styles.routineSectionTitle}>반복 패턴</Text>
-            <View style={styles.routinePrimaryCategoryButtonSection}>
-              <Pressable
-                style={[
-                  styles.routinePrimaryCategoryButton,
-                  selectedPrimaryCategory === 'DAILY' && { borderColor: theme.COLORS.DEFAULT.BLACK },
-                ]}
-                onPress={handlePrimaryCategory('DAILY')}
-              >
-                <Text style={styles.routinePrimaryCategoryButtonText}>매일</Text>
-              </Pressable>
-              <Pressable
-                style={[
-                  styles.routinePrimaryCategoryButton,
-                  selectedPrimaryCategory === 'WEEKLY' && { borderColor: theme.COLORS.DEFAULT.BLACK },
-                ]}
-                onPress={handlePrimaryCategory('WEEKLY')}
-              >
-                <Text style={styles.routinePrimaryCategoryButtonText}>매 주</Text>
-              </Pressable>
-              <Pressable
-                style={[
-                  styles.routinePrimaryCategoryButton,
-                  selectedPrimaryCategory === 'MONTHLY' && { borderColor: theme.COLORS.DEFAULT.BLACK },
-                ]}
-                onPress={handlePrimaryCategory('MONTHLY')}
-              >
-                <Text style={styles.routinePrimaryCategoryButtonText}>매 월</Text>
-              </Pressable>
-            </View>
-            {selectedPrimaryCategory === 'WEEKLY' && (
-              <View style={{ flexDirection: 'row', gap: 6 }}>
-                {WEEKLY_DAY_INFO.map(({ code, value, name }) => (
-                  <Pressable
-                    key={code}
+        <View style={styles.routineSection}>
+          <Text style={styles.routineSectionTitle}>반복 패턴</Text>
+          <View style={styles.routinePrimaryCategoryButtonSection}>
+            <Pressable
+              style={[
+                styles.routinePrimaryCategoryButton,
+                selectedPrimaryCategory === 'DAILY' && { borderColor: theme.COLORS.DEFAULT.BLACK },
+              ]}
+              onPress={handlePrimaryCategory('DAILY')}
+            >
+              <Text style={styles.routinePrimaryCategoryButtonText}>매일</Text>
+            </Pressable>
+            <Pressable
+              style={[
+                styles.routinePrimaryCategoryButton,
+                selectedPrimaryCategory === 'WEEKLY' && { borderColor: theme.COLORS.DEFAULT.BLACK },
+              ]}
+              onPress={handlePrimaryCategory('WEEKLY')}
+            >
+              <Text style={styles.routinePrimaryCategoryButtonText}>매 주</Text>
+            </Pressable>
+            <Pressable
+              style={[
+                styles.routinePrimaryCategoryButton,
+                selectedPrimaryCategory === 'MONTHLY' && { borderColor: theme.COLORS.DEFAULT.BLACK },
+              ]}
+              onPress={handlePrimaryCategory('MONTHLY')}
+            >
+              <Text style={styles.routinePrimaryCategoryButtonText}>매 월</Text>
+            </Pressable>
+          </View>
+          {selectedPrimaryCategory === 'WEEKLY' && (
+            <View style={{ flexDirection: 'row', gap: 6 }}>
+              {WEEKLY_DAY_INFO.map(({ code, value, name }) => (
+                <Pressable
+                  key={code}
+                  style={{
+                    flex: 1,
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    height: 38,
+                    borderRadius: 8,
+                    backgroundColor: selectedWeeklyDaySet.has(value)
+                      ? theme.COLORS.GRAY_SCALE.GRAY_30
+                      : theme.COLORS.GRAY_SCALE.GRAY_96,
+                  }}
+                  onPress={() => {
+                    setSelectedWeeklyDaySet(prev => {
+                      const newSet = new Set(prev);
+                      if (newSet.has(value)) {
+                        newSet.delete(value);
+                      } else {
+                        newSet.add(value);
+                      }
+                      return newSet;
+                    });
+                  }}
+                >
+                  <Text
                     style={{
-                      flex: 1,
-                      justifyContent: 'center',
-                      alignItems: 'center',
-                      height: 38,
-                      borderRadius: 8,
-                      backgroundColor: selectedWeeklyDaySet.has(value)
-                        ? theme.COLORS.GRAY_SCALE.GRAY_30
-                        : theme.COLORS.GRAY_SCALE.GRAY_96,
-                    }}
-                    onPress={() => {
-                      setSelectedWeeklyDaySet(prev => {
-                        const newSet = new Set(prev);
-                        if (newSet.has(value)) {
-                          newSet.delete(value);
-                        } else {
-                          newSet.add(value);
-                        }
-                        return newSet;
-                      });
+                      color: selectedWeeklyDaySet.has(value) ? theme.COLORS.DEFAULT.WHITE : theme.COLORS.DEFAULT.BLACK,
                     }}
                   >
-                    <Text
-                      style={{
-                        color: selectedWeeklyDaySet.has(value)
-                          ? theme.COLORS.DEFAULT.WHITE
-                          : theme.COLORS.DEFAULT.BLACK,
-                      }}
-                    >
-                      {name}
-                    </Text>
-                  </Pressable>
-                ))}
-              </View>
-            )}
-            {selectedPrimaryCategory === 'MONTHLY' && (
-              <View style={{ flexDirection: 'row', gap: 6, flexWrap: 'wrap', alignItems: 'flex-start' }}>
-                {Array.from({ length: 32 }, (_, index) => (
-                  <Pressable
-                    key={index + 1}
+                    {name}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          )}
+          {selectedPrimaryCategory === 'MONTHLY' && (
+            <View style={{ flexDirection: 'row', gap: 6, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+              {Array.from({ length: 32 }, (_, index) => (
+                <Pressable
+                  key={index + 1}
+                  style={{
+                    // TODO: % 단위 말고 다른 방법으로 구현 필요
+                    width: index !== 31 ? '12.2857%' : '54.1429%',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    height: 38,
+                    borderRadius: 8,
+                    backgroundColor: selectedMonthlyDaySet.has(index + 1)
+                      ? theme.COLORS.GRAY_SCALE.GRAY_30
+                      : theme.COLORS.GRAY_SCALE.GRAY_96,
+                  }}
+                  onPress={() => {
+                    setSelectedMonthlyDaySet(prev => {
+                      const newSet = new Set(prev);
+                      if (newSet.has(index + 1)) {
+                        newSet.delete(index + 1);
+                      } else {
+                        newSet.add(index + 1);
+                      }
+                      return newSet;
+                    });
+                  }}
+                >
+                  <Text
                     style={{
-                      // TODO: % 단위 말고 다른 방법으로 구현 필요
-                      width: index !== 31 ? '12.2857%' : '54.1429%',
-                      justifyContent: 'center',
-                      alignItems: 'center',
-                      height: 38,
-                      borderRadius: 8,
-                      backgroundColor: selectedMonthlyDaySet.has(index + 1)
-                        ? theme.COLORS.GRAY_SCALE.GRAY_30
-                        : theme.COLORS.GRAY_SCALE.GRAY_96,
-                    }}
-                    onPress={() => {
-                      setSelectedMonthlyDaySet(prev => {
-                        const newSet = new Set(prev);
-                        if (newSet.has(index + 1)) {
-                          newSet.delete(index + 1);
-                        } else {
-                          newSet.add(index + 1);
-                        }
-                        return newSet;
-                      });
+                      color: selectedMonthlyDaySet.has(index + 1)
+                        ? theme.COLORS.DEFAULT.WHITE
+                        : theme.COLORS.DEFAULT.BLACK,
                     }}
                   >
-                    <Text
-                      style={{
-                        color: selectedMonthlyDaySet.has(index + 1)
-                          ? theme.COLORS.DEFAULT.WHITE
-                          : theme.COLORS.DEFAULT.BLACK,
-                      }}
-                    >
-                      {index < 31 ? index + 1 : '마지막 날'}
-                    </Text>
-                  </Pressable>
-                ))}
-              </View>
-            )}
-          </View>
-        )}
-        {isTodoMode && (
-          <View style={styles.selectHolidaySection}>
-            <View style={styles.selectHolidayTitleWrap}>
-              <Text style={theme.TYPOGRAPHY.SUB_TITLE}>공휴일 제외하기</Text>
-              <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>(선택)</Text>
+                    {index < 31 ? index + 1 : '마지막 날'}
+                  </Text>
+                </Pressable>
+              ))}
             </View>
-            <Switch
-              value={isExcludeHolidays}
-              color={theme.COLORS.PRIMARY.RED_60}
-              onValueChange={handleExcludeHolidays}
-            />
+          )}
+        </View>
+        <View style={styles.selectHolidaySection}>
+          <View style={styles.selectHolidayTitleWrap}>
+            <Text style={theme.TYPOGRAPHY.SUB_TITLE}>공휴일 제외하기</Text>
+            <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>(선택)</Text>
           </View>
-        )}
+          <Switch value={isExcludeHolidays} color={theme.COLORS.PRIMARY.RED_60} onValueChange={handleExcludeHolidays} />
+        </View>
       </View>
     </BottomSheet>
   );

--- a/src/components/Task/Form/index.tsx
+++ b/src/components/Task/Form/index.tsx
@@ -19,6 +19,7 @@ import { ExclamationMarkCircle } from 'components/common/icons/ExclamationMarkCi
 import { useAddTodoTask } from 'hooks/queries/task/useAddTodoTask';
 import type { addTaskRequestSchemeType } from 'types/task/scheme/api';
 import { useAddDowithTask } from 'hooks/queries/task/useAddDowithTask';
+import { isNil } from 'utils/index';
 
 const Form = () => {
   const { control, watch, setValue, handleSubmit } = useFormContext<addTaskRequestSchemeType>();
@@ -64,7 +65,7 @@ const Form = () => {
 
   const handleDateChange = useCallback(
     (date: Date) => {
-      setValue('startTime', dayjs(date).format('HH:mm:ss'));
+      setValue('startTime', dayjs(date).format('HH:mm') + ':00');
       setDatePickerOpen(false);
     },
     [setValue],
@@ -87,13 +88,18 @@ const Form = () => {
 
   const onSubmit: SubmitHandler<addTaskRequestSchemeType> = useCallback(
     values => {
-      console.log(values);
+      const payload = {
+        ...values,
+        ...(isNil(values.routineCondition?.startDate) && { routineCondition: null }),
+      };
+
+      console.log(payload);
       if (isTodoMode) {
-        addTodoTaskMutate(values);
+        addTodoTaskMutate(payload);
         return;
       }
 
-      addDowithTaskMutate(values);
+      addDowithTaskMutate(payload);
     },
     [isTodoMode],
   );
@@ -190,7 +196,9 @@ const Form = () => {
                   </Text>
                 )}
               </View>
-              <Text style={startTime ? styles.value : styles.emptyValue}>{startTime || '미등록'}</Text>
+              <Text style={startTime ? styles.value : styles.emptyValue}>
+                {startTime ? dayjs(startTime, 'HH:mm:ss').format('HH:mm') : '미등록'}
+              </Text>
             </Pressable>
             <Controller
               name="taskCategoryId"

--- a/src/components/Task/Form/index.tsx
+++ b/src/components/Task/Form/index.tsx
@@ -18,6 +18,7 @@ import { useFetchTaskCategoryList } from 'hooks/queries/task/useFetchTaskCategor
 import { ExclamationMarkCircle } from 'components/common/icons/ExclamationMarkCircle';
 import { useAddTodoTask } from 'hooks/queries/task/useAddTodoTask';
 import type { addTodoTaskRequestSchemeType } from 'types/task/scheme/api';
+import { useAddDowithTask } from 'hooks/queries/task/useAddDowithTask';
 
 const Form = () => {
   const { control, watch, setValue, handleSubmit } = useFormContext<addTodoTaskRequestSchemeType>();
@@ -28,6 +29,7 @@ const Form = () => {
   const [taskMode, setTaskMode] = useState<TaskModeType | null>(null);
   const { data: taskCategoryList } = useFetchTaskCategoryList();
   const { mutate: addTodoTaskMutate, isPending: isAddTodoTaskMutateLoading } = useAddTodoTask();
+  const { mutate: addDowithTaskMutate, isPending: isAddDowithTaskMutateLoading } = useAddDowithTask();
 
   const title = watch('title');
   const startTime = watch('startTime');
@@ -36,7 +38,9 @@ const Form = () => {
 
   const isTodoMode = taskMode === 'TODO';
   const isFormDisabled = taskMode === null;
-  const isButtonDisabled = isTodoMode ? !title || isAddTodoTaskMutateLoading : !title || !startTime;
+  const isButtonDisabled = isTodoMode
+    ? !title || isAddTodoTaskMutateLoading
+    : !title || !startTime || isAddDowithTaskMutateLoading;
   const prevSelectedCategory = taskCategoryList?.find(({ id }) => taskCategoryId === id);
 
   const toggleDatePicker = useCallback(
@@ -60,7 +64,7 @@ const Form = () => {
 
   const handleDateChange = useCallback(
     (date: Date) => {
-      setValue('startTime', dayjs(date).format('HH:mm'));
+      setValue('startTime', dayjs(date).format('HH:mm:ss'));
       setDatePickerOpen(false);
     },
     [setValue],
@@ -81,10 +85,18 @@ const Form = () => {
     routineBottomSheetMethodsRef.current?.present();
   }, [isFormDisabled]);
 
-  const onSubmit: SubmitHandler<addTodoTaskRequestSchemeType> = useCallback(values => {
-    console.log(values);
-    addTodoTaskMutate(values);
-  }, []);
+  const onSubmit: SubmitHandler<addTodoTaskRequestSchemeType> = useCallback(
+    values => {
+      console.log(values);
+      if (isTodoMode) {
+        addTodoTaskMutate(values);
+        return;
+      }
+
+      addDowithTaskMutate(values);
+    },
+    [isTodoMode],
+  );
 
   return (
     <>
@@ -252,7 +264,9 @@ const Form = () => {
           <Text
             style={[
               styles.buttonText,
-              isAddTodoTaskMutateLoading && { backgroundColor: theme.COLORS.GRAY_SCALE.GRAY_80 },
+              (isAddTodoTaskMutateLoading || isAddDowithTaskMutateLoading) && {
+                backgroundColor: theme.COLORS.GRAY_SCALE.GRAY_80,
+              },
             ]}
           >
             저장하기

--- a/src/components/Task/Form/index.tsx
+++ b/src/components/Task/Form/index.tsx
@@ -17,11 +17,11 @@ import { RoutineBottomSheet } from 'components/Task/BottomSheet/RoutineBottomShe
 import { useFetchTaskCategoryList } from 'hooks/queries/task/useFetchTaskCategoryList';
 import { ExclamationMarkCircle } from 'components/common/icons/ExclamationMarkCircle';
 import { useAddTodoTask } from 'hooks/queries/task/useAddTodoTask';
-import type { addTodoTaskRequestSchemeType } from 'types/task/scheme/api';
+import type { addTaskRequestSchemeType } from 'types/task/scheme/api';
 import { useAddDowithTask } from 'hooks/queries/task/useAddDowithTask';
 
 const Form = () => {
-  const { control, watch, setValue, handleSubmit } = useFormContext<addTodoTaskRequestSchemeType>();
+  const { control, watch, setValue, handleSubmit } = useFormContext<addTaskRequestSchemeType>();
   const categoryBottomSheetMethodsRef = useRef<BottomSheetModalMethods>(null);
   const routineBottomSheetMethodsRef = useRef<BottomSheetModalMethods>(null);
 
@@ -85,7 +85,7 @@ const Form = () => {
     routineBottomSheetMethodsRef.current?.present();
   }, [isFormDisabled]);
 
-  const onSubmit: SubmitHandler<addTodoTaskRequestSchemeType> = useCallback(
+  const onSubmit: SubmitHandler<addTaskRequestSchemeType> = useCallback(
     values => {
       console.log(values);
       if (isTodoMode) {

--- a/src/components/Task/Form/index.tsx
+++ b/src/components/Task/Form/index.tsx
@@ -1,6 +1,6 @@
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import React, { useCallback, useRef, useState } from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, SubmitHandler, useFormContext } from 'react-hook-form';
 import DatePicker from 'react-native-date-picker';
 import { getBottomSpace } from 'react-native-iphone-screen-helper';
 import type { BottomSheetModalMethods } from '@gorhom/bottom-sheet/src/types';
@@ -20,7 +20,7 @@ import { useAddTodoTask } from 'hooks/queries/task/useAddTodoTask';
 import type { addTodoTaskRequestSchemeType } from 'types/task/scheme/api';
 
 const Form = () => {
-  const { control, watch, setValue, handleSubmit } = useFormContext();
+  const { control, watch, setValue, handleSubmit } = useFormContext<addTodoTaskRequestSchemeType>();
   const categoryBottomSheetMethodsRef = useRef<BottomSheetModalMethods>(null);
   const routineBottomSheetMethodsRef = useRef<BottomSheetModalMethods>(null);
 
@@ -81,7 +81,7 @@ const Form = () => {
     routineBottomSheetMethodsRef.current?.present();
   }, [isFormDisabled]);
 
-  const onSubmit = useCallback((values: addTodoTaskRequestSchemeType) => {
+  const onSubmit: SubmitHandler<addTodoTaskRequestSchemeType> = useCallback(values => {
     console.log(values);
     addTodoTaskMutate(values);
   }, []);
@@ -198,7 +198,7 @@ const Form = () => {
                       (선택)
                     </Text>
                   </View>
-                  <Text style={[styles.emptyValue, taskCategoryId && styles.value]}>
+                  <Text style={[styles.emptyValue, taskCategoryId !== null && styles.value]}>
                     {prevSelectedCategory ? prevSelectedCategory.title : '미등록'}
                   </Text>
                 </Pressable>

--- a/src/components/Task/Form/index.tsx
+++ b/src/components/Task/Form/index.tsx
@@ -15,6 +15,7 @@ import type { TaskModeType } from 'types/shared';
 import { CategoryBottomSheet } from 'components/Task/BottomSheet/CategoryBottomSheet';
 import { RoutineBottomSheet } from 'components/Task/BottomSheet/RoutineBottomSheet';
 import { useFetchTaskCategoryList } from 'hooks/queries/task/useFetchTaskCategoryList';
+import { ExclamationMarkCircle } from 'components/common/icons/ExclamationMarkCircle';
 
 const Form = () => {
   const { control, watch, setValue, handleSubmit } = useFormContext();
@@ -26,11 +27,12 @@ const Form = () => {
   const { data: taskCategoryList } = useFetchTaskCategoryList();
 
   const title = watch('title');
-  const startDateTime = watch('startDateTime');
+  const startTime = watch('startTime');
   const taskCategoryId = watch('taskCategoryId');
+  const routineConditionCycle = watch('routineCondition.cycle');
 
   const isFormDisabled = taskMode === null;
-  const isButtonDisabled = !title || !startDateTime;
+  const isButtonDisabled = !title || !startTime;
   const prevSelectedCategory = taskCategoryList?.find(({ id }) => taskCategoryId === id);
 
   const toggleDatePicker = useCallback(
@@ -54,7 +56,7 @@ const Form = () => {
 
   const handleDateChange = useCallback(
     (date: Date) => {
-      setValue('startDateTime', dayjs(date).format('HH:mm'));
+      setValue('startTime', dayjs(date).format('HH:mm'));
       setDatePickerOpen(false);
     },
     [setValue],
@@ -85,7 +87,7 @@ const Form = () => {
         <View>
           <View style={styles.modeWrap}>
             <View style={styles.modeLabel}>
-              <Text style={styles.labelTitle}>모드 선택</Text>
+              <Text style={theme.TYPOGRAPHY.SUB_TITLE}>모드 선택</Text>
               <View style={styles.modeLabelAlertWrap}>
                 <Text style={styles.modeLabelAlert}>사용 가능한 두윗 모드: 3개</Text>
                 <QuestionCircle />
@@ -128,7 +130,9 @@ const Form = () => {
           <View style={{ gap: 16, marginTop: 32 }}>
             <View style={{ gap: 12 }}>
               <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                <Text style={[styles.labelTitle, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}>
+                <Text
+                  style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}
+                >
                   제목
                 </Text>
                 <Text style={isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }}>{title.length}/40</Text>
@@ -157,10 +161,10 @@ const Form = () => {
               style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
               onPress={toggleDatePicker(true)}
             >
-              <Text style={[styles.labelTitle, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}>
+              <Text style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}>
                 시작 시간
               </Text>
-              <Text style={startDateTime ? styles.value : styles.emptyValue}>{startDateTime || '미등록'}</Text>
+              <Text style={startTime ? styles.value : styles.emptyValue}>{startTime || '미등록'}</Text>
             </Pressable>
             <Controller
               name="taskCategoryId"
@@ -171,10 +175,14 @@ const Form = () => {
                   onPress={handlePresentModalPress}
                 >
                   <View style={styles.optionalLabelWrap}>
-                    <Text style={[styles.labelTitle, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}>
+                    <Text
+                      style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}
+                    >
                       카테고리
                     </Text>
-                    <Text style={styles.optionalLabel}>(선택)</Text>
+                    <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>
+                      (선택)
+                    </Text>
                   </View>
                   <Text style={[styles.emptyValue, taskCategoryId && styles.value]}>
                     {prevSelectedCategory ? prevSelectedCategory.title : '미등록'}
@@ -186,13 +194,39 @@ const Form = () => {
               style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
               onPress={handleTaskRoutine}
             >
-              <View style={styles.optionalLabelWrap}>
-                <Text style={[styles.labelTitle, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}>
-                  루틴 설정
-                </Text>
-                <Text style={styles.optionalLabel}>(선택)</Text>
+              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                <View style={{ gap: 8 }}>
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                    <Text
+                      style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}
+                    >
+                      루틴 설정
+                    </Text>
+                    <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>
+                      (선택)
+                    </Text>
+                  </View>
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                    <ExclamationMarkCircle />
+                    <Text
+                      style={[
+                        theme.TYPOGRAPHY.CAPTION1_BASIC,
+                        { color: isFormDisabled ? theme.COLORS.GRAY_SCALE.GRAY_80 : theme.COLORS.GRAY_SCALE.GRAY_50 },
+                      ]}
+                    >
+                      모드를 변경하면 루틴이 초기화 돼요.
+                    </Text>
+                  </View>
+                </View>
               </View>
-              <Text style={styles.emptyValue}>미등록</Text>
+              <Text
+                style={[
+                  theme.TYPOGRAPHY.BODY_2,
+                  { color: routineConditionCycle ? theme.COLORS.DEFAULT.BLACK : theme.COLORS.GRAY_SCALE.GRAY_80 },
+                ]}
+              >
+                {routineConditionCycle ? '사용자 지정' : '미등록'}
+              </Text>
             </Pressable>
           </View>
         </View>
@@ -245,11 +279,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: theme.COLORS.GRAY_SCALE.GRAY_60,
   },
-  labelTitle: {
-    fontSize: 14,
-    fontWeight: 'bold',
-    color: theme.COLORS.DEFAULT.BLACK,
-  },
   modeButtonWrap: {
     flexDirection: 'row',
     gap: 8,
@@ -272,10 +301,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-  },
-  optionalLabel: {
-    color: theme.COLORS.GRAY_SCALE.GRAY_70,
-    fontSize: 12,
   },
   emptyValue: {
     color: theme.COLORS.GRAY_SCALE.GRAY_80,

--- a/src/components/Task/Form/index.tsx
+++ b/src/components/Task/Form/index.tsx
@@ -16,6 +16,8 @@ import { CategoryBottomSheet } from 'components/Task/BottomSheet/CategoryBottomS
 import { RoutineBottomSheet } from 'components/Task/BottomSheet/RoutineBottomSheet';
 import { useFetchTaskCategoryList } from 'hooks/queries/task/useFetchTaskCategoryList';
 import { ExclamationMarkCircle } from 'components/common/icons/ExclamationMarkCircle';
+import { useAddTodoTask } from 'hooks/queries/task/useAddTodoTask';
+import type { addTodoTaskRequestSchemeType } from 'types/task/scheme/api';
 
 const Form = () => {
   const { control, watch, setValue, handleSubmit } = useFormContext();
@@ -25,14 +27,16 @@ const Form = () => {
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
   const [taskMode, setTaskMode] = useState<TaskModeType | null>(null);
   const { data: taskCategoryList } = useFetchTaskCategoryList();
+  const { mutate: addTodoTaskMutate, isPending: isAddTodoTaskMutateLoading } = useAddTodoTask();
 
   const title = watch('title');
   const startTime = watch('startTime');
   const taskCategoryId = watch('taskCategoryId');
   const routineConditionCycle = watch('routineCondition.cycle');
 
+  const isTodoMode = taskMode === 'TODO';
   const isFormDisabled = taskMode === null;
-  const isButtonDisabled = !title || !startTime;
+  const isButtonDisabled = isTodoMode ? !title || isAddTodoTaskMutateLoading : !title || !startTime;
   const prevSelectedCategory = taskCategoryList?.find(({ id }) => taskCategoryId === id);
 
   const toggleDatePicker = useCallback(
@@ -77,8 +81,9 @@ const Form = () => {
     routineBottomSheetMethodsRef.current?.present();
   }, [isFormDisabled]);
 
-  const onSubmit = useCallback<any>((values: FormData) => {
+  const onSubmit = useCallback((values: addTodoTaskRequestSchemeType) => {
     console.log(values);
+    addTodoTaskMutate(values);
   }, []);
 
   return (
@@ -107,7 +112,7 @@ const Form = () => {
               >
                 <TodoMode />
                 <Text style={[styles.modeButtonText, taskMode === 'TODO' && { color: theme.COLORS.SECONDARY.BLUE_60 }]}>
-                  혼자 하는 투두 모드
+                  혼자 하는 TO DO
                 </Text>
               </Pressable>
               <Pressable
@@ -122,7 +127,7 @@ const Form = () => {
               >
                 <DowithMode />
                 <Text style={[styles.modeButtonText, taskMode === 'DOWITH' && { color: theme.COLORS.PRIMARY.RED_60 }]}>
-                  혼자 하는 두윗 모드
+                  함께 하는 DO WITH
                 </Text>
               </Pressable>
             </View>
@@ -161,9 +166,18 @@ const Form = () => {
               style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
               onPress={toggleDatePicker(true)}
             >
-              <Text style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}>
-                시작 시간
-              </Text>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                <Text
+                  style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}
+                >
+                  시작 시간
+                </Text>
+                {taskMode === 'TODO' && (
+                  <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>
+                    (선택)
+                  </Text>
+                )}
+              </View>
               <Text style={startTime ? styles.value : styles.emptyValue}>{startTime || '미등록'}</Text>
             </Pressable>
             <Controller
@@ -235,7 +249,14 @@ const Form = () => {
           disabled={isButtonDisabled}
           onPress={handleSubmit(onSubmit)}
         >
-          <Text style={styles.buttonText}>저장하기</Text>
+          <Text
+            style={[
+              styles.buttonText,
+              isAddTodoTaskMutateLoading && { backgroundColor: theme.COLORS.GRAY_SCALE.GRAY_80 },
+            ]}
+          >
+            저장하기
+          </Text>
         </Pressable>
       </View>
       <DatePicker

--- a/src/components/Task/ListContainerView/index.tsx
+++ b/src/components/Task/ListContainerView/index.tsx
@@ -151,6 +151,8 @@ const ListContainerView = ({ selectedDate }: Props) => {
   const yearMonth = useMemo(() => ({ year, month }), [year, month]);
   const { data: taskList } = useFetchTaskList(yearMonth);
 
+  console.log('taskList: ', taskList);
+  // TODO: taskList 날짜별로 필터링 필요
   return taskList ? (
     <ScrollView contentContainerStyle={{ paddingBottom: 134, gap: 16 }} showsVerticalScrollIndicator={false}>
       <List type="DOWITH" items={taskList.dowithTasks} />

--- a/src/components/Task/ListContainerView/index.tsx
+++ b/src/components/Task/ListContainerView/index.tsx
@@ -151,12 +151,17 @@ const ListContainerView = ({ selectedDate }: Props) => {
   const yearMonth = useMemo(() => ({ year, month }), [year, month]);
   const { data: taskList } = useFetchTaskList(yearMonth);
 
-  console.log('taskList: ', taskList);
-  // TODO: taskList 날짜별로 필터링 필요
-  return taskList ? (
+  const filteredTaskList = taskList
+    ? {
+        dowithTasks: taskList.dowithTasks.filter(task => task.date === selectedDate),
+        todoTasks: taskList.todoTasks.filter(task => task.date === selectedDate),
+      }
+    : null;
+
+  return filteredTaskList ? (
     <ScrollView contentContainerStyle={{ paddingBottom: 134, gap: 16 }} showsVerticalScrollIndicator={false}>
-      <List type="DOWITH" items={taskList.dowithTasks} />
-      <List type="TODO" items={taskList.todoTasks} />
+      <List type="DOWITH" items={filteredTaskList.dowithTasks} />
+      <List type="TODO" items={filteredTaskList.todoTasks} />
     </ScrollView>
   ) : null;
 };

--- a/src/constants/queries/index.ts
+++ b/src/constants/queries/index.ts
@@ -12,6 +12,7 @@ const MEMBER_QUERY_KEY = {
 const TASK_QUERY_KEY = {
   CATEGORY_LIST: ['task', 'category', 'list'],
   LIST: ['task', 'list'],
+  ADD_TODO: ['task', 'add', 'todo'],
 } as const;
 
 export { AUTH_QUERY_KEY, MEMBER_QUERY_KEY, TASK_QUERY_KEY };

--- a/src/constants/queries/index.ts
+++ b/src/constants/queries/index.ts
@@ -13,6 +13,7 @@ const TASK_QUERY_KEY = {
   CATEGORY_LIST: ['task', 'category', 'list'],
   LIST: ['task', 'list'],
   ADD_TODO: ['task', 'add', 'todo'],
+  ADD_DOWITH: ['task', 'add', 'dowith'],
 } as const;
 
 export { AUTH_QUERY_KEY, MEMBER_QUERY_KEY, TASK_QUERY_KEY };

--- a/src/hooks/queries/auth/useFetchTokenQuery.ts
+++ b/src/hooks/queries/auth/useFetchTokenQuery.ts
@@ -33,13 +33,13 @@ const useFetchTokenQuery = () => {
         return;
       }
 
-      if (!data.atk || !data.rtk || !data.memberId) {
+      if (!data.accessToken || !data.refreshToken || !data.memberId) {
         return;
       }
 
       // 이미 존재하는 회원일 경우
       setIsNeedSignUp(false);
-      setTokenInfo({ access: data.atk, refresh: data.rtk });
+      setTokenInfo({ access: data.accessToken, refresh: data.refreshToken });
       setMemberId(data.memberId);
     },
     onError: e => {

--- a/src/hooks/queries/auth/useRefreshTokenQuery.ts
+++ b/src/hooks/queries/auth/useRefreshTokenQuery.ts
@@ -25,12 +25,12 @@ const useRefreshTokenQuery = () => {
     mutationKey: AUTH_QUERY_KEY.REFRESH_TOKEN,
     mutationFn: payload => refreshToken(payload),
     onSuccess: ({ data }) => {
-      if (!data.atk || !data.rtk || !data.memberId) {
+      if (!data.accessToken || !data.refreshToken || !data.memberId) {
         return;
       }
 
       // 토큰 재발급이 완료 되었을 경우
-      setTokenInfo({ access: data.atk, refresh: data.rtk });
+      setTokenInfo({ access: data.accessToken, refresh: data.refreshToken });
       setIsLoggedIn(true);
       setIsNeedRefreshToken(false);
       setIsNeedSignUp(false);

--- a/src/hooks/queries/member/useSignUp.ts
+++ b/src/hooks/queries/member/useSignUp.ts
@@ -21,7 +21,7 @@ const useSignUp = () => {
     onSuccess: ({ data }) => {
       console.log('signup success data: ', data);
       setIsNeedSignUp(false);
-      setTokenInfo({ access: data.atk, refresh: data.rtk, signup: null });
+      setTokenInfo({ access: data.accessToken, refresh: data.refreshToken, signup: null });
       setMemberId(data.memberId);
     },
     onError: e => {

--- a/src/hooks/queries/task/useAddDowithTask.ts
+++ b/src/hooks/queries/task/useAddDowithTask.ts
@@ -5,13 +5,13 @@ import type { StackNavigationProp } from '@react-navigation/stack';
 
 import { TASK_QUERY_KEY } from 'constants/queries';
 import { addDowithTask } from 'services/rest/task';
-import type { addTodoTaskRequestSchemeType } from 'types/task/scheme/api';
+import type { addTaskRequestSchemeType } from 'types/task/scheme/api';
 import type { RootStackParamList } from 'types/shared';
 
 const useAddDowithTask = () => {
   const { navigate } = useNavigation<StackNavigationProp<RootStackParamList, 'TASK_FORM'>>();
 
-  return useMutation<string, AxiosError, addTodoTaskRequestSchemeType>({
+  return useMutation<string, AxiosError, addTaskRequestSchemeType>({
     mutationKey: TASK_QUERY_KEY.ADD_DOWITH,
     mutationFn: payload => addDowithTask(payload),
     onSuccess: async response => {

--- a/src/hooks/queries/task/useAddDowithTask.ts
+++ b/src/hooks/queries/task/useAddDowithTask.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useNavigation } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
+
+import { TASK_QUERY_KEY } from 'constants/queries';
+import { addDowithTask } from 'services/rest/task';
+import type { addTodoTaskRequestSchemeType } from 'types/task/scheme/api';
+import type { RootStackParamList } from 'types/shared';
+
+const useAddDowithTask = () => {
+  const { navigate } = useNavigation<StackNavigationProp<RootStackParamList, 'TASK_FORM'>>();
+
+  return useMutation<string, AxiosError, addTodoTaskRequestSchemeType>({
+    mutationKey: TASK_QUERY_KEY.ADD_DOWITH,
+    mutationFn: payload => addDowithTask(payload),
+    onSuccess: async response => {
+      console.log('두윗 등록 성공!: ', response);
+      navigate('HOME');
+      // TODO: 테스크 리스트 query invalidate 필요
+    },
+    onError: e => {
+      console.error('두윗 등록 실패 ', e.response?.data);
+    },
+  });
+};
+
+export { useAddDowithTask };

--- a/src/hooks/queries/task/useAddDowithTask.ts
+++ b/src/hooks/queries/task/useAddDowithTask.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
@@ -9,18 +9,16 @@ import type { addTaskRequestSchemeType } from 'types/task/scheme/api';
 import type { RootStackParamList } from 'types/shared';
 
 const useAddDowithTask = () => {
+  const queryClient = useQueryClient();
   const { navigate } = useNavigation<StackNavigationProp<RootStackParamList, 'TASK_FORM'>>();
 
-  return useMutation<string, AxiosError, addTaskRequestSchemeType>({
+  return useMutation<undefined, AxiosError, addTaskRequestSchemeType>({
     mutationKey: TASK_QUERY_KEY.ADD_DOWITH,
     mutationFn: payload => addDowithTask(payload),
-    onSuccess: async response => {
-      console.log('두윗 등록 성공!: ', response);
+    onSuccess: () => {
+      console.log('두윗 등록 성공! ');
       navigate('HOME');
-      // TODO: 테스크 리스트 query invalidate 필요
-    },
-    onError: e => {
-      console.error('두윗 등록 실패 ', e.response?.data);
+      queryClient.invalidateQueries({ queryKey: TASK_QUERY_KEY.LIST });
     },
   });
 };

--- a/src/hooks/queries/task/useAddTodoTask.ts
+++ b/src/hooks/queries/task/useAddTodoTask.ts
@@ -1,26 +1,24 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
 
 import { TASK_QUERY_KEY } from 'constants/queries';
 import { addTodoTask } from 'services/rest/task';
-import type { addTaskRequestSchemeType, addTodoTaskResponseSchemeType } from 'types/task/scheme/api';
+import type { addTaskRequestSchemeType } from 'types/task/scheme/api';
 import type { RootStackParamList } from 'types/shared';
 
 const useAddTodoTask = () => {
+  const queryClient = useQueryClient();
   const { navigate } = useNavigation<StackNavigationProp<RootStackParamList, 'TASK_FORM'>>();
 
-  return useMutation<addTodoTaskResponseSchemeType, AxiosError, addTaskRequestSchemeType>({
+  return useMutation<undefined, AxiosError, addTaskRequestSchemeType>({
     mutationKey: TASK_QUERY_KEY.ADD_TODO,
     mutationFn: payload => addTodoTask(payload),
-    onSuccess: async ({ data }) => {
-      console.log('투두 등록 성공!: ', data);
+    onSuccess: () => {
+      console.log('투두 등록 성공! ');
       navigate('HOME');
-      // TODO: 테스크 리스트 query invalidate 필요
-    },
-    onError: e => {
-      console.error('투두 등록 실패 ', e.response?.data);
+      queryClient.invalidateQueries({ queryKey: TASK_QUERY_KEY.LIST });
     },
   });
 };

--- a/src/hooks/queries/task/useAddTodoTask.ts
+++ b/src/hooks/queries/task/useAddTodoTask.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useNavigation } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
+
+import { TASK_QUERY_KEY } from 'constants/queries';
+import { addTodoTask } from 'services/rest/task';
+import type { addTodoTaskRequestSchemeType, addTodoTaskResponseSchemeType } from 'types/task/scheme/api';
+import type { RootStackParamList } from 'types/shared';
+
+const useAddTodoTask = () => {
+  const { navigate } = useNavigation<StackNavigationProp<RootStackParamList, 'TASK_FORM'>>();
+
+  return useMutation<addTodoTaskResponseSchemeType, AxiosError, addTodoTaskRequestSchemeType>({
+    mutationKey: TASK_QUERY_KEY.ADD_TODO,
+    mutationFn: payload => addTodoTask(payload),
+    onSuccess: async ({ data }) => {
+      console.log('투두 등록 성공!: ', data);
+      navigate('HOME');
+      // TODO: 테스크 리스트 query invalidate 필요
+    },
+    onError: e => {
+      console.error('투두 등록 실패 ', e.response?.data);
+    },
+  });
+};
+
+export { useAddTodoTask };

--- a/src/hooks/queries/task/useAddTodoTask.ts
+++ b/src/hooks/queries/task/useAddTodoTask.ts
@@ -5,13 +5,13 @@ import type { StackNavigationProp } from '@react-navigation/stack';
 
 import { TASK_QUERY_KEY } from 'constants/queries';
 import { addTodoTask } from 'services/rest/task';
-import type { addTodoTaskRequestSchemeType, addTodoTaskResponseSchemeType } from 'types/task/scheme/api';
+import type { addTaskRequestSchemeType, addTodoTaskResponseSchemeType } from 'types/task/scheme/api';
 import type { RootStackParamList } from 'types/shared';
 
 const useAddTodoTask = () => {
   const { navigate } = useNavigation<StackNavigationProp<RootStackParamList, 'TASK_FORM'>>();
 
-  return useMutation<addTodoTaskResponseSchemeType, AxiosError, addTodoTaskRequestSchemeType>({
+  return useMutation<addTodoTaskResponseSchemeType, AxiosError, addTaskRequestSchemeType>({
     mutationKey: TASK_QUERY_KEY.ADD_TODO,
     mutationFn: payload => addTodoTask(payload),
     onSuccess: async ({ data }) => {

--- a/src/schemes/auth/api.ts
+++ b/src/schemes/auth/api.ts
@@ -15,8 +15,8 @@ const fetchTokenRequestScheme = z.object({
 
 const fetchTokenResponseScheme = BaseResponseScheme.extend({
   data: z.object({
-    atk: tokenScheme.nullable(),
-    rtk: tokenScheme.nullable(),
+    accessToken: tokenScheme.nullable(),
+    refreshToken: tokenScheme.nullable(),
     signupToken: tokenScheme.nullable(),
     memberId: z.string(),
   }),
@@ -28,8 +28,8 @@ const refreshTokenRequestScheme = z.object({
 
 const refreshTokenResponseScheme = BaseResponseScheme.extend({
   data: z.object({
-    atk: tokenScheme,
-    rtk: tokenScheme,
+    accessToken: tokenScheme,
+    refreshToken: tokenScheme,
     memberId: z.string(),
   }),
 });

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -53,31 +53,15 @@ const addTaskRequestScheme = z.object({
   taskCategoryId: z.number().nullable().describe('테스크 카테고리 id'),
   date: z.string().describe('테스크 수행일자'),
   startTime: z.string().nullable().describe('테스크 시작시간'),
-  routineCondition: z.object({
-    startDate: z.string().nullable().describe('루틴 시작일자'),
-    endDate: z.string().nullable().describe('루틴 종료일자'),
-    cycle: TASK_ROUTINE_CYCLE_ENUM.nullable().describe('루틴 주기'),
-    pattern: z.array(z.number()).describe('루틴 패턴 (요일 등)'),
-    isExcludeHolidays: z.boolean().describe('휴일 제외 여부'),
-  }),
-});
-
-const addTodoTaskResponseDataScheme = z.object({
-  todoTaskList: z.array(
-    z.object({
-      id: z.number().describe('테스크 id'),
-      taskCategoryId: z.number().nullable().describe('테스크 카테고리 id'),
-      title: z.string().describe('테스크 제목'),
-      date: z.string().describe('테스크 수행일자'),
-      startTime: z.string().nullable().describe('테스크 시작시간'),
-      isRoutine: z.boolean().describe('루틴 여부'),
-    }),
-  ),
-  routineDates: z.array(z.string()).describe('루틴 날짜 목록'),
-});
-
-const addTodoTaskResponseScheme = BaseResponseScheme.extend({
-  data: addTodoTaskResponseDataScheme,
+  routineCondition: z
+    .object({
+      startDate: z.string().describe('루틴 시작일자'),
+      endDate: z.string().describe('루틴 종료일자'),
+      cycle: TASK_ROUTINE_CYCLE_ENUM.describe('루틴 주기'),
+      pattern: z.array(z.number()).describe('루틴 패턴 (요일 등)'),
+      isExcludeHolidays: z.boolean().describe('휴일 제외 여부'),
+    })
+    .nullable(),
 });
 
 export {
@@ -89,6 +73,4 @@ export {
   fetchTaskListResponseDataScheme,
   fetchTaskListResponseScheme,
   addTaskRequestScheme,
-  addTodoTaskResponseDataScheme,
-  addTodoTaskResponseScheme,
 };

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -48,7 +48,7 @@ const fetchTaskListResponseScheme = BaseResponseScheme.extend({
   }),
 });
 
-const addTodoTaskRequestScheme = z.object({
+const addTaskRequestScheme = z.object({
   title: z.string().describe('테스크 제목'),
   taskCategoryId: z.number().nullable().describe('테스크 카테고리 id'),
   date: z.string().describe('테스크 수행일자'),
@@ -88,7 +88,7 @@ export {
   dowithTaskScheme,
   fetchTaskListResponseDataScheme,
   fetchTaskListResponseScheme,
-  addTodoTaskRequestScheme,
+  addTaskRequestScheme,
   addTodoTaskResponseDataScheme,
   addTodoTaskResponseScheme,
 };

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { BaseResponseScheme } from 'schemes/shared/api';
-import { CREATION_TYPE_ENUM, TASK_STATUS_ENUM } from 'schemes/task/enum';
+import { CREATION_TYPE_ENUM, TASK_ROUTINE_CYCLE_ENUM, TASK_STATUS_ENUM } from 'schemes/task/enum';
 
 const taskCategoryScheme = z.object({
   id: z.number().describe('조회한 Task Category의 id'),
@@ -48,6 +48,40 @@ const fetchTaskListResponseScheme = BaseResponseScheme.extend({
   }),
 });
 
+const addTodoTaskRequestScheme = z.object({
+  title: z.string().describe('테스크 제목'),
+  taskCategoryId: z.number().nullable().describe('테스크 카테고리 id'),
+  date: z.string().describe('테스크 수행일자'),
+  startTime: z.string().nullable().describe('테스크 시작시간'),
+  routineCondition: z
+    .object({
+      startDate: z.string().describe('루틴 시작일자'),
+      endDate: z.string().describe('루틴 종료일자'),
+      cycle: TASK_ROUTINE_CYCLE_ENUM.describe('루틴 주기'),
+      pattern: z.array(z.number()).describe('루틴 패턴 (요일 등)'),
+      isExcludeHolidays: z.boolean().describe('휴일 제외 여부'),
+    })
+    .optional(),
+});
+
+const addTodoTaskResponseDataScheme = z.object({
+  todoTaskList: z.array(
+    z.object({
+      id: z.number().describe('테스크 id'),
+      taskCategoryId: z.number().nullable().describe('테스크 카테고리 id'),
+      title: z.string().describe('테스크 제목'),
+      date: z.string().describe('테스크 수행일자'),
+      startTime: z.string().nullable().describe('테스크 시작시간'),
+      isRoutine: z.boolean().describe('루틴 여부'),
+    }),
+  ),
+  routineDates: z.array(z.string()).describe('루틴 날짜 목록'),
+});
+
+const addTodoTaskResponseScheme = BaseResponseScheme.extend({
+  data: addTodoTaskResponseDataScheme,
+});
+
 export {
   taskCategoryScheme,
   fetchTaskCategoryListResponseScheme,
@@ -56,4 +90,7 @@ export {
   dowithTaskScheme,
   fetchTaskListResponseDataScheme,
   fetchTaskListResponseScheme,
+  addTodoTaskRequestScheme,
+  addTodoTaskResponseDataScheme,
+  addTodoTaskResponseScheme,
 };

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -53,15 +53,13 @@ const addTodoTaskRequestScheme = z.object({
   taskCategoryId: z.number().nullable().describe('테스크 카테고리 id'),
   date: z.string().describe('테스크 수행일자'),
   startTime: z.string().nullable().describe('테스크 시작시간'),
-  routineCondition: z
-    .object({
-      startDate: z.string().describe('루틴 시작일자'),
-      endDate: z.string().describe('루틴 종료일자'),
-      cycle: TASK_ROUTINE_CYCLE_ENUM.describe('루틴 주기'),
-      pattern: z.array(z.number()).describe('루틴 패턴 (요일 등)'),
-      isExcludeHolidays: z.boolean().describe('휴일 제외 여부'),
-    })
-    .optional(),
+  routineCondition: z.object({
+    startDate: z.string().nullable().describe('루틴 시작일자'),
+    endDate: z.string().nullable().describe('루틴 종료일자'),
+    cycle: TASK_ROUTINE_CYCLE_ENUM.nullable().describe('루틴 주기'),
+    pattern: z.array(z.number()).describe('루틴 패턴 (요일 등)'),
+    isExcludeHolidays: z.boolean().describe('휴일 제외 여부'),
+  }),
 });
 
 const addTodoTaskResponseDataScheme = z.object({

--- a/src/schemes/task/enum.ts
+++ b/src/schemes/task/enum.ts
@@ -2,5 +2,6 @@ import { z } from 'zod';
 
 const CREATION_TYPE_ENUM = z.enum(['COMMON', 'USER_CUSTOM']);
 const TASK_STATUS_ENUM = z.enum(['WAIT', 'SUCCESS', 'FAIL']);
+const TASK_ROUTINE_CYCLE_ENUM = z.enum(['DAILY', 'WEEKLY', 'MONTHLY']);
 
-export { CREATION_TYPE_ENUM, TASK_STATUS_ENUM };
+export { CREATION_TYPE_ENUM, TASK_STATUS_ENUM, TASK_ROUTINE_CYCLE_ENUM };

--- a/src/screens/Home/Task/Form/index.tsx
+++ b/src/screens/Home/Task/Form/index.tsx
@@ -12,9 +12,9 @@ const TaskForm = () => {
       date: dayjs().format('YYYY-MM-DD'),
       startTime: null,
       routineCondition: {
-        startDate: null,
-        endDate: null,
-        cycle: null,
+        startDate: undefined,
+        endDate: undefined,
+        cycle: undefined,
         pattern: [],
         isExcludeHolidays: false,
       },

--- a/src/screens/Home/Task/Form/index.tsx
+++ b/src/screens/Home/Task/Form/index.tsx
@@ -7,10 +7,14 @@ const TaskForm = () => {
     defaultValues: {
       title: '',
       taskCategoryId: null,
-      startDateTime: '',
-      isRoutine: false,
-      routineStartDateTime: '',
-      routineEndDateTime: '',
+      startTime: '',
+      routineCondition: {
+        startDate: null,
+        endDate: null,
+        cycle: null,
+        pattern: [],
+        isExcludeHolidays: false,
+      },
     },
   });
 

--- a/src/screens/Home/Task/Form/index.tsx
+++ b/src/screens/Home/Task/Form/index.tsx
@@ -1,4 +1,5 @@
 import { FormProvider, useForm } from 'react-hook-form';
+import dayjs from 'dayjs';
 
 import { TaskFormStackNavigator } from 'components/navigators/Stack/Task';
 
@@ -7,6 +8,7 @@ const TaskForm = () => {
     defaultValues: {
       title: '',
       taskCategoryId: null,
+      date: dayjs().format('YYYY-MM-DD'),
       startTime: '',
       routineCondition: {
         startDate: null,

--- a/src/screens/Home/Task/Form/index.tsx
+++ b/src/screens/Home/Task/Form/index.tsx
@@ -2,14 +2,15 @@ import { FormProvider, useForm } from 'react-hook-form';
 import dayjs from 'dayjs';
 
 import { TaskFormStackNavigator } from 'components/navigators/Stack/Task';
+import type { addTodoTaskRequestSchemeType } from 'types/task/scheme/api';
 
 const TaskForm = () => {
-  const methods = useForm({
+  const methods = useForm<addTodoTaskRequestSchemeType>({
     defaultValues: {
       title: '',
       taskCategoryId: null,
       date: dayjs().format('YYYY-MM-DD'),
-      startTime: '',
+      startTime: null,
       routineCondition: {
         startDate: null,
         endDate: null,

--- a/src/screens/Home/Task/Form/index.tsx
+++ b/src/screens/Home/Task/Form/index.tsx
@@ -2,10 +2,10 @@ import { FormProvider, useForm } from 'react-hook-form';
 import dayjs from 'dayjs';
 
 import { TaskFormStackNavigator } from 'components/navigators/Stack/Task';
-import type { addTodoTaskRequestSchemeType } from 'types/task/scheme/api';
+import type { addTaskRequestSchemeType } from 'types/task/scheme/api';
 
 const TaskForm = () => {
-  const methods = useForm<addTodoTaskRequestSchemeType>({
+  const methods = useForm<addTaskRequestSchemeType>({
     defaultValues: {
       title: '',
       taskCategoryId: null,

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -37,4 +37,13 @@ const addTodoTask = async (payload: addTodoTaskRequestSchemeType): Promise<addTo
   }
 };
 
-export { fetchTaskCategoryList, fetchTaskList, addTodoTask };
+const addDowithTask = async (payload: addTodoTaskRequestSchemeType): Promise<string> => {
+  try {
+    const result = await apiClient.post<string>(TASK_API.ADD_DOWITH, payload);
+    return result.data;
+  } catch (e) {
+    throw e;
+  }
+};
+
+export { fetchTaskCategoryList, fetchTaskList, addTodoTask, addDowithTask };

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -1,6 +1,8 @@
 import { apiClient } from 'services/apiClient';
 import { TASK_API } from 'services/urls';
 import type {
+  addTodoTaskRequestSchemeType,
+  addTodoTaskResponseSchemeType,
   fetchTaskCategoryListResponseSchemeType,
   fetchTaskListRequestSchemeType,
   fetchTaskListResponseSchemeType,
@@ -26,4 +28,13 @@ const fetchTaskList = async (params: fetchTaskListRequestSchemeType): Promise<fe
   }
 };
 
-export { fetchTaskCategoryList, fetchTaskList };
+const addTodoTask = async (payload: addTodoTaskRequestSchemeType): Promise<addTodoTaskResponseSchemeType> => {
+  try {
+    const result = await apiClient.post<addTodoTaskResponseSchemeType>(TASK_API.ADD_TODO, payload);
+    return result.data;
+  } catch (e) {
+    throw e;
+  }
+};
+
+export { fetchTaskCategoryList, fetchTaskList, addTodoTask };

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -2,7 +2,6 @@ import { apiClient } from 'services/apiClient';
 import { TASK_API } from 'services/urls';
 import type {
   addTaskRequestSchemeType,
-  addTodoTaskResponseSchemeType,
   fetchTaskCategoryListResponseSchemeType,
   fetchTaskListRequestSchemeType,
   fetchTaskListResponseSchemeType,
@@ -28,18 +27,18 @@ const fetchTaskList = async (params: fetchTaskListRequestSchemeType): Promise<fe
   }
 };
 
-const addTodoTask = async (payload: addTaskRequestSchemeType): Promise<addTodoTaskResponseSchemeType> => {
+const addTodoTask = async (payload: addTaskRequestSchemeType): Promise<undefined> => {
   try {
-    const result = await apiClient.post<addTodoTaskResponseSchemeType>(TASK_API.ADD_TODO, payload);
+    const result = await apiClient.post<undefined>(TASK_API.ADD_TODO, payload);
     return result.data;
   } catch (e) {
     throw e;
   }
 };
 
-const addDowithTask = async (payload: addTaskRequestSchemeType): Promise<string> => {
+const addDowithTask = async (payload: addTaskRequestSchemeType): Promise<undefined> => {
   try {
-    const result = await apiClient.post<string>(TASK_API.ADD_DOWITH, payload);
+    const result = await apiClient.post<undefined>(TASK_API.ADD_DOWITH, payload);
     return result.data;
   } catch (e) {
     throw e;

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -1,7 +1,7 @@
 import { apiClient } from 'services/apiClient';
 import { TASK_API } from 'services/urls';
 import type {
-  addTodoTaskRequestSchemeType,
+  addTaskRequestSchemeType,
   addTodoTaskResponseSchemeType,
   fetchTaskCategoryListResponseSchemeType,
   fetchTaskListRequestSchemeType,
@@ -28,7 +28,7 @@ const fetchTaskList = async (params: fetchTaskListRequestSchemeType): Promise<fe
   }
 };
 
-const addTodoTask = async (payload: addTodoTaskRequestSchemeType): Promise<addTodoTaskResponseSchemeType> => {
+const addTodoTask = async (payload: addTaskRequestSchemeType): Promise<addTodoTaskResponseSchemeType> => {
   try {
     const result = await apiClient.post<addTodoTaskResponseSchemeType>(TASK_API.ADD_TODO, payload);
     return result.data;
@@ -37,7 +37,7 @@ const addTodoTask = async (payload: addTodoTaskRequestSchemeType): Promise<addTo
   }
 };
 
-const addDowithTask = async (payload: addTodoTaskRequestSchemeType): Promise<string> => {
+const addDowithTask = async (payload: addTaskRequestSchemeType): Promise<string> => {
   try {
     const result = await apiClient.post<string>(TASK_API.ADD_DOWITH, payload);
     return result.data;

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -12,6 +12,7 @@ const MEMBER_API = {
 const TASK_API = {
   CATEGORY_LIST: 'v1/tasks/category',
   LIST: 'v1/tasks',
+  ADD_TODO: 'v1/tasks/todo',
 } as const;
 
 export { AUTH_API, MEMBER_API, TASK_API };

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -13,6 +13,7 @@ const TASK_API = {
   CATEGORY_LIST: 'v1/tasks/category',
   LIST: 'v1/tasks',
   ADD_TODO: 'v1/tasks/todo',
+  ADD_DOWITH: 'v1/tasks/dowith',
 } as const;
 
 export { AUTH_API, MEMBER_API, TASK_API };

--- a/src/stores/auth/index.ts
+++ b/src/stores/auth/index.ts
@@ -139,11 +139,10 @@ const useAuthStore = create<State & { actions: Action }>()(
               // refresh 토큰이 만료되지 않았을 경우
               if (dayjs().isBefore(tokenInfo.refresh.expireAt)) {
                 setIsNeedRefreshToken(true);
-                return;
+              } else {
+                // refresh 토큰이 만료되었을 경우 인증 정보 상태 및 스토리지 초기화
+                initAuthInfo();
               }
-
-              // refresh 토큰이 만료되었을 경우 인증 정보 상태 및 스토리지 초기화
-              initAuthInfo();
             }
           }
 

--- a/src/stores/auth/index.ts
+++ b/src/stores/auth/index.ts
@@ -1,4 +1,3 @@
-import EncryptedStorage from 'react-native-encrypted-storage';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import dayjs from 'dayjs';
@@ -68,7 +67,7 @@ const useAuthStore = create<State & { actions: Action }>()(
             await secureStorage().setItem(STORAGE_KEY.AUTH_INFO, JSON.stringify(INITIAL_STORAGE_VALUE));
             set({ ...initialState, isHydrated: true });
           } catch (error) {
-            console.error('토큰 정보 삭제에 실패했습니다.', error);
+            console.error('인증 정보 초기화에 실패했습니다.', error);
           }
         },
       },
@@ -93,16 +92,31 @@ const useAuthStore = create<State & { actions: Action }>()(
 
         const {
           tokenInfo,
-          actions: { setIsLoggedIn, setIsNeedSignUp, setIsNeedRefreshToken, setTokenInfo, initAuthInfo, setIsHydrated },
+          memberId,
+          actions: {
+            setIsLoggedIn,
+            setIsNeedSignUp,
+            setIsNeedRefreshToken,
+            setTokenInfo,
+            initAuthInfo,
+            setIsHydrated,
+            setMemberId,
+          },
         } = mergedState;
 
         try {
-          if (!tokenInfo) {
+          // 초기 토큰 정보가 아얘 없는 경우
+          if (
+            !tokenInfo ||
+            (tokenInfo.signup === null && tokenInfo.access === null && tokenInfo.refresh === null && !memberId)
+          ) {
+            setIsHydrated(true);
             return;
           }
 
           setTokenInfo(tokenInfo);
-          setIsLoggedIn(false);
+          setMemberId(memberId);
+          setIsLoggedIn(true);
           setIsNeedSignUp(false);
           setIsNeedRefreshToken(false);
 

--- a/src/stores/auth/index.ts
+++ b/src/stores/auth/index.ts
@@ -44,7 +44,7 @@ const INITIAL_STORAGE_VALUE = {
 const initialState = {
   ...INITIAL_STORAGE_VALUE,
   isLoggedIn: false,
-  isNeedSignUp: false,
+  isNeedSignUp: true,
   isNeedRefreshToken: false,
   isHydrated: false,
 };
@@ -117,8 +117,6 @@ const useAuthStore = create<State & { actions: Action }>()(
           setTokenInfo(tokenInfo);
           setMemberId(memberId);
           setIsLoggedIn(true);
-          setIsNeedSignUp(false);
-          setIsNeedRefreshToken(false);
 
           // 회원가입을 완료하지 않았을 경우
           if (tokenInfo.signup) {
@@ -126,8 +124,8 @@ const useAuthStore = create<State & { actions: Action }>()(
             if (dayjs().isAfter(tokenInfo.signup.expireAt)) {
               setIsLoggedIn(false);
             }
-            setIsNeedSignUp(true);
           }
+          setIsNeedSignUp(false);
 
           // 액세스 토큰, refresh 토큰이 존재하는 경우
           if (tokenInfo.access && tokenInfo.refresh) {

--- a/src/types/shared/index.ts
+++ b/src/types/shared/index.ts
@@ -33,9 +33,6 @@ type TaskModeType = 'TODO' | 'DOWITH';
 
 type TaskFormStackParamList = {
   FORM: undefined;
-  ROUTINE_FORM: {
-    mode: TaskModeType;
-  };
 };
 
 type TaskFormStackScreenProps<T extends keyof TaskFormStackParamList> = StackScreenProps<TaskFormStackParamList, T>;

--- a/src/types/task/scheme/api.ts
+++ b/src/types/task/scheme/api.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
 import {
+  addTodoTaskRequestScheme,
+  addTodoTaskResponseDataScheme,
+  addTodoTaskResponseScheme,
   dowithTaskScheme,
   fetchTaskCategoryListResponseScheme,
   fetchTaskListRequestScheme,
@@ -17,6 +20,9 @@ type todoTaskSchemeType = z.infer<typeof todoTaskScheme>;
 type dowithTaskSchemeType = z.infer<typeof dowithTaskScheme>;
 type fetchTaskListResponseSchemeDataType = z.infer<typeof fetchTaskListResponseDataScheme>;
 type fetchTaskListResponseSchemeType = z.infer<typeof fetchTaskListResponseScheme>;
+type addTodoTaskRequestSchemeType = z.infer<typeof addTodoTaskRequestScheme>;
+type addTodoTaskResponseDataSchemeType = z.infer<typeof addTodoTaskResponseDataScheme>;
+type addTodoTaskResponseSchemeType = z.infer<typeof addTodoTaskResponseScheme>;
 
 export type {
   taskCategorySchemeType,
@@ -26,4 +32,7 @@ export type {
   dowithTaskSchemeType,
   fetchTaskListResponseSchemeDataType,
   fetchTaskListResponseSchemeType,
+  addTodoTaskRequestSchemeType,
+  addTodoTaskResponseDataSchemeType,
+  addTodoTaskResponseSchemeType,
 };

--- a/src/types/task/scheme/api.ts
+++ b/src/types/task/scheme/api.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import {
-  addTodoTaskRequestScheme,
+  addTaskRequestScheme,
   addTodoTaskResponseDataScheme,
   addTodoTaskResponseScheme,
   dowithTaskScheme,
@@ -20,7 +20,7 @@ type todoTaskSchemeType = z.infer<typeof todoTaskScheme>;
 type dowithTaskSchemeType = z.infer<typeof dowithTaskScheme>;
 type fetchTaskListResponseSchemeDataType = z.infer<typeof fetchTaskListResponseDataScheme>;
 type fetchTaskListResponseSchemeType = z.infer<typeof fetchTaskListResponseScheme>;
-type addTodoTaskRequestSchemeType = z.infer<typeof addTodoTaskRequestScheme>;
+type addTaskRequestSchemeType = z.infer<typeof addTaskRequestScheme>;
 type addTodoTaskResponseDataSchemeType = z.infer<typeof addTodoTaskResponseDataScheme>;
 type addTodoTaskResponseSchemeType = z.infer<typeof addTodoTaskResponseScheme>;
 
@@ -32,7 +32,7 @@ export type {
   dowithTaskSchemeType,
   fetchTaskListResponseSchemeDataType,
   fetchTaskListResponseSchemeType,
-  addTodoTaskRequestSchemeType,
+  addTaskRequestSchemeType,
   addTodoTaskResponseDataSchemeType,
   addTodoTaskResponseSchemeType,
 };

--- a/src/types/task/scheme/api.ts
+++ b/src/types/task/scheme/api.ts
@@ -2,8 +2,6 @@ import { z } from 'zod';
 
 import {
   addTaskRequestScheme,
-  addTodoTaskResponseDataScheme,
-  addTodoTaskResponseScheme,
   dowithTaskScheme,
   fetchTaskCategoryListResponseScheme,
   fetchTaskListRequestScheme,
@@ -21,8 +19,6 @@ type dowithTaskSchemeType = z.infer<typeof dowithTaskScheme>;
 type fetchTaskListResponseSchemeDataType = z.infer<typeof fetchTaskListResponseDataScheme>;
 type fetchTaskListResponseSchemeType = z.infer<typeof fetchTaskListResponseScheme>;
 type addTaskRequestSchemeType = z.infer<typeof addTaskRequestScheme>;
-type addTodoTaskResponseDataSchemeType = z.infer<typeof addTodoTaskResponseDataScheme>;
-type addTodoTaskResponseSchemeType = z.infer<typeof addTodoTaskResponseScheme>;
 
 export type {
   taskCategorySchemeType,
@@ -33,6 +29,4 @@ export type {
   fetchTaskListResponseSchemeDataType,
   fetchTaskListResponseSchemeType,
   addTaskRequestSchemeType,
-  addTodoTaskResponseDataSchemeType,
-  addTodoTaskResponseSchemeType,
 };


### PR DESCRIPTION
## 🤔 개요
투두/두윗 Task 등록 API 연동 및 토큰 refresh 관련 로직, task 관련 데이터 스키마 수정 해야 함

## 📝 작업 내용
1. 투두/두윗 Task 등록 API 연동
2. 토큰 refresh 관련 로직 수정
3. task 관련 데이터 스키마 수정
4. 선택한 날로 task 리스트 필터링
5. 앱 진입 시, 초기 인증 로직 수정

## 📸 작업 화면
<table>
<tr>
<td>🤖 AOS</td>
<td>🍎 IOS</td>
</tr>
<tr>
<td>


https://github.com/user-attachments/assets/970efc14-59c8-4a77-9107-e7aa3c923c5d
</td>
<td>


https://github.com/user-attachments/assets/b228eb2c-3a40-4746-b69d-9e1cc1d5a6ae
</td>
</tr>
</table>


## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-389](https://www.notion.so/Task-API-1f7df3a3e43f80fdaf9dceb0eab93289?v=72865a96132e456c873537e8de4c3757&source=copy_link)
[TAS-391](https://www.notion.so/Task-API-1f7df3a3e43f80bfa881dff1b9c25983?v=72865a96132e456c873537e8de4c3757&source=copy_link)