### PR TITLE
[TAS-477]add: Task 단일 조회 API 연동

### DIFF
--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -1,12 +1,14 @@
 import React, { useRef } from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 import { TaskSuccess } from 'components/common/icons/TaskSuccess';
 import { EtcDots } from 'components/common/icons/EtcDots';
 import { theme } from 'styles/theme';
-import type { TaskModeType } from 'types/shared';
+import type { RootStackParamList, TaskModeType } from 'types/shared';
 import { BottomSheet } from 'components/common/BottomSheet';
 import { TaskEdit } from 'components/common/icons/TaskEdit';
 import { RoutineEdit } from 'components/common/icons/RoutineEdit';
@@ -20,6 +22,7 @@ import { TaskFail } from 'components/common/icons/TaskFail';
 import { UploadImage } from 'components/common/icons/UploadImage';
 import { isNil } from 'utils/index';
 import { useUpdateTodoTask } from 'hooks/queries/task/useUpdateTodoTask';
+import { isAos } from 'utils/device';
 
 dayjs.extend(customParseFormat);
 
@@ -48,6 +51,7 @@ const Item = ({
   confirmedImageUrl,
   feedBackCount,
 }: Props) => {
+  const { navigate } = useNavigation<StackNavigationProp<RootStackParamList>>();
   const taskManagementBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const isDisabled = status === TASK_STATUS_ENUM.enum.FAIL;
 
@@ -150,12 +154,19 @@ const Item = ({
           </View>
         </View>
       </View>
-      <BottomSheet ref={taskManagementBottomSheetModalRef} title="투두 관리하기" snapPoints={['29%']}>
+      <BottomSheet ref={taskManagementBottomSheetModalRef} title="투두 관리하기" snapPoints={[isAos ? '31%' : '29%']}>
         <View style={styles.modalContainer}>
-          <View style={styles.modalContentRow}>
+          <Pressable
+            style={styles.modalContentRow}
+            onPress={() => {
+              // TODO: date params를 선택한 날짜로 변경 필요
+              navigate('TASK_FORM', { date: dayjs().toString() });
+              taskManagementBottomSheetModalRef.current?.dismiss();
+            }}
+          >
             <TaskEdit />
             <Text style={styles.modalContentText}>할 일 수정하기</Text>
-          </View>
+          </Pressable>
           <View style={styles.modalContentRow}>
             <RoutineEdit />
             <Text style={styles.modalContentText}>루틴 수정하기</Text>

--- a/src/hooks/queries/task/useFetchDowithTask.ts
+++ b/src/hooks/queries/task/useFetchDowithTask.ts
@@ -1,0 +1,19 @@
+import { AxiosError } from 'axios';
+import { useQuery } from '@tanstack/react-query';
+
+import { TASK_QUERY_KEY } from 'constants/queries';
+import { fetchDowithTask } from 'services/rest/task';
+import type {
+  addTaskRequestSchemeType,
+  fetchDowithTaskRequestSchemeType,
+  fetchDowithTaskResponseSchemeType,
+} from 'types/task/scheme/api';
+
+const useFetchDowithTask = ({ dowithTaskId }: fetchDowithTaskRequestSchemeType) =>
+  useQuery<fetchDowithTaskResponseSchemeType, AxiosError, addTaskRequestSchemeType>({
+    queryKey: [...TASK_QUERY_KEY.LIST, dowithTaskId],
+    queryFn: () => fetchDowithTask({ dowithTaskId }),
+    select: data => data.data,
+  });
+
+export { useFetchDowithTask };

--- a/src/hooks/queries/task/useFetchTodoTask.ts
+++ b/src/hooks/queries/task/useFetchTodoTask.ts
@@ -1,0 +1,19 @@
+import { AxiosError } from 'axios';
+import { useQuery } from '@tanstack/react-query';
+
+import { TASK_QUERY_KEY } from 'constants/queries';
+import { fetchTodoTask } from 'services/rest/task';
+import type {
+  fetchTodoTaskRequestSchemeType,
+  fetchTodoTaskResponseDataSchemeType,
+  fetchTodoTaskResponseSchemeType,
+} from 'types/task/scheme/api';
+
+const useFetchTodoTask = ({ todoTaskId }: fetchTodoTaskRequestSchemeType) =>
+  useQuery<fetchTodoTaskResponseSchemeType, AxiosError, fetchTodoTaskResponseDataSchemeType>({
+    queryKey: [...TASK_QUERY_KEY.LIST, todoTaskId],
+    queryFn: () => fetchTodoTask({ todoTaskId }),
+    select: data => data.data,
+  });
+
+export { useFetchTodoTask };

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -64,6 +64,24 @@ const updateTodoTaskResponseScheme = BaseResponseScheme.extend({
   data: z.number().describe('완료된 task id'),
 });
 
+const fetchTodoTaskRequestScheme = z.object({
+  todoTaskId: z.number().describe('투두 task id'),
+});
+
+const fetchTodoTaskResponseDataScheme = todoTaskScheme.extend({
+  routineCondition: z
+    .object({
+      startDate: z.string().describe('루틴 시작일자'),
+      endDate: z.string().describe('루틴 종료일자'),
+      cycle: TASK_ROUTINE_CYCLE_ENUM.describe('루틴 주기'),
+      pattern: z.array(z.number()).describe('루틴 패턴 (요일 등)'),
+      isExcludeHolidays: z.boolean().describe('휴일 제외 여부'),
+    })
+    .nullable(),
+});
+
+const fetchTodoTaskResponseScheme = BaseResponseScheme.extend({ data: fetchTodoTaskResponseDataScheme });
+
 const fetchDowithTaskRequestScheme = z.object({
   dowithTaskId: z.number().describe('두윗 task id'),
 });
@@ -75,6 +93,9 @@ export {
   fetchTaskCategoryListResponseScheme,
   fetchTaskListRequestScheme,
   todoTaskScheme,
+  fetchTodoTaskRequestScheme,
+  fetchTodoTaskResponseDataScheme,
+  fetchTodoTaskResponseScheme,
   dowithTaskScheme,
   fetchTaskListResponseDataScheme,
   fetchTaskListResponseScheme,

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -48,11 +48,7 @@ const fetchTaskListResponseScheme = BaseResponseScheme.extend({
   }),
 });
 
-const addTaskRequestScheme = z.object({
-  title: z.string().describe('테스크 제목'),
-  taskCategoryId: z.number().nullable().describe('테스크 카테고리 id'),
-  date: z.string().describe('테스크 수행일자'),
-  startTime: z.string().nullable().describe('테스크 시작시간'),
+const addTaskRequestScheme = todoTaskScheme.omit({ id: true, status: true, taskCategoryName: true }).extend({
   routineCondition: z
     .object({
       startDate: z.string().describe('루틴 시작일자'),
@@ -68,6 +64,12 @@ const updateTodoTaskResponseScheme = BaseResponseScheme.extend({
   data: z.number().describe('완료된 task id'),
 });
 
+const fetchDowithTaskRequestScheme = z.object({
+  dowithTaskId: z.number().describe('두윗 task id'),
+});
+
+const fetchDowithTaskResponseScheme = BaseResponseScheme.extend({ data: addTaskRequestScheme });
+
 export {
   taskCategoryScheme,
   fetchTaskCategoryListResponseScheme,
@@ -78,4 +80,6 @@ export {
   fetchTaskListResponseScheme,
   addTaskRequestScheme,
   updateTodoTaskResponseScheme,
+  fetchDowithTaskRequestScheme,
+  fetchDowithTaskResponseScheme,
 };

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -7,6 +7,8 @@ import type {
   fetchTaskCategoryListResponseSchemeType,
   fetchTaskListRequestSchemeType,
   fetchTaskListResponseSchemeType,
+  fetchTodoTaskRequestSchemeType,
+  fetchTodoTaskResponseSchemeType,
   updateTodoTaskResponseSchemeType,
 } from 'types/task/scheme/api';
 import type { TaskStatusEnumType } from 'types/task/scheme/enum';
@@ -41,11 +43,22 @@ const addTodoTask = async (payload: addTaskRequestSchemeType): Promise<undefined
   }
 };
 
-const fetchDowithTask = async (
-  params: fetchDowithTaskRequestSchemeType,
-): Promise<fetchDowithTaskResponseSchemeType> => {
+const fetchTodoTask = async ({
+  todoTaskId,
+}: fetchTodoTaskRequestSchemeType): Promise<fetchTodoTaskResponseSchemeType> => {
   try {
-    const result = await apiClient.get<fetchDowithTaskResponseSchemeType>(TASK_API.LIST, { params });
+    const result = await apiClient.get<fetchTodoTaskResponseSchemeType>(`${TASK_API.ADD_TODO}/${todoTaskId}`);
+    return result.data;
+  } catch (e) {
+    throw e;
+  }
+};
+
+const fetchDowithTask = async ({
+  dowithTaskId,
+}: fetchDowithTaskRequestSchemeType): Promise<fetchDowithTaskResponseSchemeType> => {
+  try {
+    const result = await apiClient.get<fetchDowithTaskResponseSchemeType>(`${TASK_API.ADD_DOWITH}/${dowithTaskId}`);
     return result.data;
   } catch (e) {
     throw e;
@@ -77,4 +90,12 @@ const updateStatusTodoTask = async ({
   }
 };
 
-export { fetchTaskCategoryList, fetchTaskList, addTodoTask, fetchDowithTask, addDowithTask, updateStatusTodoTask };
+export {
+  fetchTaskCategoryList,
+  fetchTaskList,
+  addTodoTask,
+  fetchTodoTask,
+  fetchDowithTask,
+  addDowithTask,
+  updateStatusTodoTask,
+};

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -2,6 +2,8 @@ import { apiClient } from 'services/apiClient';
 import { TASK_API } from 'services/urls';
 import type {
   addTaskRequestSchemeType,
+  fetchDowithTaskRequestSchemeType,
+  fetchDowithTaskResponseSchemeType,
   fetchTaskCategoryListResponseSchemeType,
   fetchTaskListRequestSchemeType,
   fetchTaskListResponseSchemeType,
@@ -39,6 +41,17 @@ const addTodoTask = async (payload: addTaskRequestSchemeType): Promise<undefined
   }
 };
 
+const fetchDowithTask = async (
+  params: fetchDowithTaskRequestSchemeType,
+): Promise<fetchDowithTaskResponseSchemeType> => {
+  try {
+    const result = await apiClient.get<fetchDowithTaskResponseSchemeType>(TASK_API.LIST, { params });
+    return result.data;
+  } catch (e) {
+    throw e;
+  }
+};
+
 const addDowithTask = async (payload: addTaskRequestSchemeType): Promise<undefined> => {
   try {
     const result = await apiClient.post<undefined>(TASK_API.ADD_DOWITH, payload);
@@ -64,4 +77,4 @@ const updateStatusTodoTask = async ({
   }
 };
 
-export { fetchTaskCategoryList, fetchTaskList, addTodoTask, addDowithTask, updateStatusTodoTask };
+export { fetchTaskCategoryList, fetchTaskList, addTodoTask, fetchDowithTask, addDowithTask, updateStatusTodoTask };

--- a/src/types/task/scheme/api.ts
+++ b/src/types/task/scheme/api.ts
@@ -10,10 +10,14 @@ import {
   updateTodoTaskResponseScheme,
   taskCategoryScheme,
   todoTaskScheme,
+  fetchDowithTaskRequestScheme,
+  fetchDowithTaskResponseScheme,
 } from 'schemes/task/api';
 
 type taskCategorySchemeType = z.infer<typeof taskCategoryScheme>;
 type fetchTaskCategoryListResponseSchemeType = z.infer<typeof fetchTaskCategoryListResponseScheme>;
+type fetchDowithTaskRequestSchemeType = z.infer<typeof fetchDowithTaskRequestScheme>;
+type fetchDowithTaskResponseSchemeType = z.infer<typeof fetchDowithTaskResponseScheme>;
 type fetchTaskListRequestSchemeType = z.infer<typeof fetchTaskListRequestScheme>;
 type todoTaskSchemeType = z.infer<typeof todoTaskScheme>;
 type dowithTaskSchemeType = z.infer<typeof dowithTaskScheme>;
@@ -25,6 +29,8 @@ type updateTodoTaskResponseSchemeType = z.infer<typeof updateTodoTaskResponseSch
 export type {
   taskCategorySchemeType,
   fetchTaskCategoryListResponseSchemeType,
+  fetchDowithTaskRequestSchemeType,
+  fetchDowithTaskResponseSchemeType,
   fetchTaskListRequestSchemeType,
   todoTaskSchemeType,
   dowithTaskSchemeType,

--- a/src/types/task/scheme/api.ts
+++ b/src/types/task/scheme/api.ts
@@ -12,10 +12,16 @@ import {
   todoTaskScheme,
   fetchDowithTaskRequestScheme,
   fetchDowithTaskResponseScheme,
+  fetchTodoTaskResponseScheme,
+  fetchTodoTaskRequestScheme,
+  fetchTodoTaskResponseDataScheme,
 } from 'schemes/task/api';
 
 type taskCategorySchemeType = z.infer<typeof taskCategoryScheme>;
 type fetchTaskCategoryListResponseSchemeType = z.infer<typeof fetchTaskCategoryListResponseScheme>;
+type fetchTodoTaskRequestSchemeType = z.infer<typeof fetchTodoTaskRequestScheme>;
+type fetchTodoTaskResponseDataSchemeType = z.infer<typeof fetchTodoTaskResponseDataScheme>;
+type fetchTodoTaskResponseSchemeType = z.infer<typeof fetchTodoTaskResponseScheme>;
 type fetchDowithTaskRequestSchemeType = z.infer<typeof fetchDowithTaskRequestScheme>;
 type fetchDowithTaskResponseSchemeType = z.infer<typeof fetchDowithTaskResponseScheme>;
 type fetchTaskListRequestSchemeType = z.infer<typeof fetchTaskListRequestScheme>;
@@ -29,6 +35,9 @@ type updateTodoTaskResponseSchemeType = z.infer<typeof updateTodoTaskResponseSch
 export type {
   taskCategorySchemeType,
   fetchTaskCategoryListResponseSchemeType,
+  fetchTodoTaskRequestSchemeType,
+  fetchTodoTaskResponseDataSchemeType,
+  fetchTodoTaskResponseSchemeType,
   fetchDowithTaskRequestSchemeType,
   fetchDowithTaskResponseSchemeType,
   fetchTaskListRequestSchemeType,


### PR DESCRIPTION
## 🤔 개요
Task 수정 페이지 구현을 위해 Task 단일 조회 API 연동 선작업이 필요함

## 📝 작업 내용
1. Task 단일 조회 API 연동(투두, 두윗)
2. Task 수정하기 screen으로 이동하는 로직 추가

<!-- (선택)작업한 내용에 대해 달라진 화면을 스크린샷이나 동영상으로 첨부하여 보여주세요 
## 📸 작업 화면
<table>
<tr>
<td></td>
<td>AS-IS</td>
<td>TO-BE</td>
</tr>
<tr>
<td>🤖 AOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요 
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
<tr>
<td>🍎 IOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
</table>
-->

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
- [TAS-477](https://www.notion.so/Task-API-258df3a3e43f8048b5bfcf12588fde21?v=72865a96132e456c873537e8de4c3757&source=copy_link)
- [TAS-478](https://www.notion.so/Task-API-258df3a3e43f800b9197f510310dfe51?v=72865a96132e456c873537e8de4c3757&source=copy_link)