### PR TITLE
[TAS-497]add: Task 수정하기 페이지 화면 구현

### DIFF
--- a/src/components/Task/Form/index.tsx
+++ b/src/components/Task/Form/index.tsx
@@ -11,7 +11,7 @@ import { isAos } from 'utils/device';
 import { TodoMode } from 'components/common/icons/TodoMode';
 import { DowithMode } from 'components/common/icons/DowithMode';
 import { QuestionCircle } from 'components/common/icons/QuestionCircle';
-import type { TaskModeType } from 'types/shared';
+import type { TaskFormStackParamList, TaskModeType } from 'types/shared';
 import { CategoryBottomSheet } from 'components/Task/BottomSheet/CategoryBottomSheet';
 import { RoutineBottomSheet } from 'components/Task/BottomSheet/RoutineBottomSheet';
 import { useFetchTaskCategoryList } from 'hooks/queries/task/useFetchTaskCategoryList';
@@ -20,17 +20,26 @@ import { useAddTodoTask } from 'hooks/queries/task/useAddTodoTask';
 import type { addTaskRequestSchemeType } from 'types/task/scheme/api';
 import { useAddDowithTask } from 'hooks/queries/task/useAddDowithTask';
 import { isNil } from 'utils/index';
+import { StackScreenProps } from '@react-navigation/stack';
 
-const Form = () => {
-  const { control, watch, setValue, handleSubmit } = useFormContext<addTaskRequestSchemeType>();
+const Form = ({ route }: StackScreenProps<TaskFormStackParamList, 'FORM'>) => {
+  const { params } = route;
+  const {
+    control,
+    watch,
+    setValue,
+    handleSubmit,
+    formState: { dirtyFields },
+  } = useFormContext<addTaskRequestSchemeType>();
   const categoryBottomSheetMethodsRef = useRef<BottomSheetModalMethods>(null);
   const routineBottomSheetMethodsRef = useRef<BottomSheetModalMethods>(null);
 
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
-  const [taskMode, setTaskMode] = useState<TaskModeType | null>(null);
+  const [taskMode, setTaskMode] = useState<TaskModeType | null>(params.mode ?? null);
   const { data: taskCategoryList } = useFetchTaskCategoryList();
   const { mutate: addTodoTaskMutate, isPending: isAddTodoTaskMutateLoading } = useAddTodoTask();
   const { mutate: addDowithTaskMutate, isPending: isAddDowithTaskMutateLoading } = useAddDowithTask();
+  const isFieldChanged = Object.keys(dirtyFields).length > 0;
 
   const title = watch('title');
   const startTime = watch('startTime');
@@ -40,9 +49,103 @@ const Form = () => {
   const isTodoMode = taskMode === 'TODO';
   const isFormDisabled = taskMode === null;
   const isButtonDisabled = isTodoMode
-    ? !title || isAddTodoTaskMutateLoading
-    : !title || !startTime || isAddDowithTaskMutateLoading;
+    ? !isFieldChanged || !title || isAddTodoTaskMutateLoading
+    : !isFieldChanged || !title || !startTime || isAddDowithTaskMutateLoading;
   const prevSelectedCategory = taskCategoryList?.find(({ id }) => taskCategoryId === id);
+
+  const renderTaskModeButtonView = () => {
+    if (!params.mode) {
+      return (
+        <>
+          <View style={styles.modeLabel}>
+            <Text style={theme.TYPOGRAPHY.SUB_TITLE}>모드 선택</Text>
+            <View style={styles.modeLabelAlertWrap}>
+              <Text style={styles.modeLabelAlert}>사용 가능한 두윗 모드: 3개</Text>
+              <QuestionCircle />
+            </View>
+          </View>
+          <View style={styles.modeButtonWrap}>
+            <Pressable
+              style={[
+                styles.modeButton,
+                taskMode === 'TODO' && {
+                  backgroundColor: theme.COLORS.SECONDARY.BLUE_95,
+                  borderColor: theme.COLORS.SECONDARY.BLUE_95,
+                },
+              ]}
+              onPress={handleTaskMode('TODO')}
+            >
+              <TodoMode />
+              <Text style={[styles.modeButtonText, taskMode === 'TODO' && { color: theme.COLORS.SECONDARY.BLUE_60 }]}>
+                혼자 하는 TO DO
+              </Text>
+            </Pressable>
+            <Pressable
+              style={[
+                styles.modeButton,
+                taskMode === 'DOWITH' && {
+                  backgroundColor: theme.COLORS.PRIMARY.RED_98,
+                  borderColor: theme.COLORS.PRIMARY.RED_98,
+                },
+              ]}
+              onPress={handleTaskMode('DOWITH')}
+            >
+              <DowithMode />
+              <Text style={[styles.modeButtonText, taskMode === 'DOWITH' && { color: theme.COLORS.PRIMARY.RED_60 }]}>
+                함께 하는 DO WITH
+              </Text>
+            </Pressable>
+          </View>
+        </>
+      );
+    }
+
+    if (params.mode === 'TODO') {
+      return (
+        <View style={[styles.modeButtonWrap]}>
+          <Pressable
+            style={[
+              styles.modeButton,
+              {
+                flexDirection: 'row',
+                justifyContent: 'center',
+                gap: 4,
+                paddingVertical: 10,
+                backgroundColor: theme.COLORS.SECONDARY.BLUE_95,
+                borderColor: theme.COLORS.SECONDARY.BLUE_95,
+                borderRadius: 8,
+              },
+            ]}
+          >
+            <TodoMode width={20} height={20} />
+            <Text style={[theme.TYPOGRAPHY.SUB_TITLE, { color: theme.COLORS.SECONDARY.BLUE_60 }]}>TO DO</Text>
+          </Pressable>
+        </View>
+      );
+    }
+
+    return (
+      <View style={[styles.modeButtonWrap]}>
+        <Pressable
+          style={[
+            styles.modeButton,
+            {
+              flexDirection: 'row',
+              justifyContent: 'center',
+              gap: 4,
+              paddingVertical: 10,
+              backgroundColor: theme.COLORS.PRIMARY.RED_98,
+              borderColor: theme.COLORS.PRIMARY.RED_98,
+              borderRadius: 8,
+            },
+          ]}
+        >
+          <DowithMode width={24} height={20} />
+          <Text style={[theme.TYPOGRAPHY.SUB_TITLE, { color: theme.COLORS.PRIMARY.RED_60 }]}>DO WITH</Text>
+        </Pressable>
+      </View>
+    );
+  };
 
   const toggleDatePicker = useCallback(
     (isOpen: boolean) => () => {
@@ -108,48 +211,7 @@ const Form = () => {
     <>
       <View style={styles.container}>
         <View>
-          <View style={styles.modeWrap}>
-            <View style={styles.modeLabel}>
-              <Text style={theme.TYPOGRAPHY.SUB_TITLE}>모드 선택</Text>
-              <View style={styles.modeLabelAlertWrap}>
-                <Text style={styles.modeLabelAlert}>사용 가능한 두윗 모드: 3개</Text>
-                <QuestionCircle />
-              </View>
-            </View>
-            {/* TODO: 모드 변경 불가능하게 해야 함*/}
-            <View style={styles.modeButtonWrap}>
-              <Pressable
-                style={[
-                  styles.modeButton,
-                  taskMode === 'TODO' && {
-                    backgroundColor: theme.COLORS.SECONDARY.BLUE_95,
-                    borderColor: theme.COLORS.SECONDARY.BLUE_95,
-                  },
-                ]}
-                onPress={handleTaskMode('TODO')}
-              >
-                <TodoMode />
-                <Text style={[styles.modeButtonText, taskMode === 'TODO' && { color: theme.COLORS.SECONDARY.BLUE_60 }]}>
-                  혼자 하는 TO DO
-                </Text>
-              </Pressable>
-              <Pressable
-                style={[
-                  styles.modeButton,
-                  taskMode === 'DOWITH' && {
-                    backgroundColor: theme.COLORS.PRIMARY.RED_98,
-                    borderColor: theme.COLORS.PRIMARY.RED_98,
-                  },
-                ]}
-                onPress={handleTaskMode('DOWITH')}
-              >
-                <DowithMode />
-                <Text style={[styles.modeButtonText, taskMode === 'DOWITH' && { color: theme.COLORS.PRIMARY.RED_60 }]}>
-                  함께 하는 DO WITH
-                </Text>
-              </Pressable>
-            </View>
-          </View>
+          <View style={styles.modeWrap}>{renderTaskModeButtonView()}</View>
           <View style={{ gap: 16, marginTop: 32 }}>
             <View style={{ gap: 12 }}>
               <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
@@ -224,44 +286,49 @@ const Form = () => {
                 </Pressable>
               )}
             />
-            <Pressable
-              style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
-              onPress={handleTaskRoutine}
-            >
-              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                <View style={{ gap: 8 }}>
-                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                    <Text
-                      style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}
-                    >
-                      루틴 설정
-                    </Text>
-                    <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>
-                      (선택)
-                    </Text>
-                  </View>
-                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                    <ExclamationMarkCircle />
-                    <Text
-                      style={[
-                        theme.TYPOGRAPHY.CAPTION1_BASIC,
-                        { color: isFormDisabled ? theme.COLORS.GRAY_SCALE.GRAY_80 : theme.COLORS.GRAY_SCALE.GRAY_50 },
-                      ]}
-                    >
-                      모드를 변경하면 루틴이 초기화 돼요.
-                    </Text>
+            {!params.mode ? (
+              <Pressable
+                style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
+                onPress={handleTaskRoutine}
+              >
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <View style={{ gap: 8 }}>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                      <Text
+                        style={[
+                          theme.TYPOGRAPHY.SUB_TITLE,
+                          isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 },
+                        ]}
+                      >
+                        루틴 설정
+                      </Text>
+                      <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>
+                        (선택)
+                      </Text>
+                    </View>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                      <ExclamationMarkCircle />
+                      <Text
+                        style={[
+                          theme.TYPOGRAPHY.CAPTION1_BASIC,
+                          { color: isFormDisabled ? theme.COLORS.GRAY_SCALE.GRAY_80 : theme.COLORS.GRAY_SCALE.GRAY_50 },
+                        ]}
+                      >
+                        모드를 변경하면 루틴이 초기화 돼요.
+                      </Text>
+                    </View>
                   </View>
                 </View>
-              </View>
-              <Text
-                style={[
-                  theme.TYPOGRAPHY.BODY_2,
-                  { color: routineConditionCycle ? theme.COLORS.DEFAULT.BLACK : theme.COLORS.GRAY_SCALE.GRAY_80 },
-                ]}
-              >
-                {routineConditionCycle ? '사용자 지정' : '미등록'}
-              </Text>
-            </Pressable>
+                <Text
+                  style={[
+                    theme.TYPOGRAPHY.BODY_2,
+                    { color: routineConditionCycle ? theme.COLORS.DEFAULT.BLACK : theme.COLORS.GRAY_SCALE.GRAY_80 },
+                  ]}
+                >
+                  {routineConditionCycle ? '사용자 지정' : '미등록'}
+                </Text>
+              </Pressable>
+            ) : null}
           </View>
         </View>
         <Pressable
@@ -305,7 +372,8 @@ const Form = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingVertical: isAos ? 24 : getBottomSpace() + 24,
+    paddingTop: 24,
+    paddingBottom: isAos ? 24 : getBottomSpace() + 24,
     paddingHorizontal: 20,
     justifyContent: 'space-between',
   },

--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -21,7 +21,7 @@ import { FeedBackIcon } from 'components/common/icons/FeedBackIcon';
 import { TaskFail } from 'components/common/icons/TaskFail';
 import { UploadImage } from 'components/common/icons/UploadImage';
 import { isNil } from 'utils/index';
-import { useUpdateTodoTask } from 'hooks/queries/task/useUpdateTodoTask';
+import { useUpdateTodoTaskStatus } from 'hooks/queries/task/useUpdateTodoTaskStatus';
 import { isAos } from 'utils/device';
 import { useFetchTodoTask } from 'hooks/queries/task/useFetchTodoTask';
 import { useFetchDowithTask } from 'hooks/queries/task/useFetchDowithTask';
@@ -59,7 +59,7 @@ const Item = ({
   const taskManagementBottomSheetModalRef = useRef<BottomSheetModal>(null);
   const isDisabled = status === TASK_STATUS_ENUM.enum.FAIL;
 
-  const { mutate: completeTodoTaskMutate } = useUpdateTodoTask({ year, month });
+  const { mutate: completeTodoTaskStatusMutate } = useUpdateTodoTaskStatus({ year, month });
   const { data: todoTaskData } = useFetchTodoTask({ todoTaskId: id }, { enabled: mode === 'TODO' && id !== -1 });
   const { data: dowithTaskData } = useFetchDowithTask(
     { dowithTaskId: id },
@@ -107,7 +107,7 @@ const Item = ({
       return;
     }
 
-    completeTodoTaskMutate({ id, status });
+    completeTodoTaskStatusMutate({ id, status });
   };
 
   const handleEditTask = () => {

--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -35,6 +35,7 @@ interface Props {
   startTime: string | null;
   year: number;
   month: number;
+  selectedDate: string;
   confirmedImageUrl?: string | null;
   feedBackCount?: number | null;
 }
@@ -48,6 +49,7 @@ const Item = ({
   startTime,
   year,
   month,
+  selectedDate,
   confirmedImageUrl,
   feedBackCount,
 }: Props) => {
@@ -88,6 +90,11 @@ const Item = ({
     }
 
     completeTodoTaskMutate({ id, status });
+  };
+
+  const handleEditTask = () => {
+    navigate('TASK_FORM', { date: selectedDate, id, mode });
+    taskManagementBottomSheetModalRef.current?.dismiss();
   };
 
   return (
@@ -156,14 +163,7 @@ const Item = ({
       </View>
       <BottomSheet ref={taskManagementBottomSheetModalRef} title="투두 관리하기" snapPoints={[isAos ? '31%' : '29%']}>
         <View style={styles.modalContainer}>
-          <Pressable
-            style={styles.modalContentRow}
-            onPress={() => {
-              // TODO: date params를 선택한 날짜로 변경 필요
-              navigate('TASK_FORM', { date: dayjs().toString() });
-              taskManagementBottomSheetModalRef.current?.dismiss();
-            }}
-          >
+          <Pressable style={styles.modalContentRow} onPress={handleEditTask}>
             <TaskEdit />
             <Text style={styles.modalContentText}>할 일 수정하기</Text>
           </Pressable>

--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -23,6 +23,8 @@ import { UploadImage } from 'components/common/icons/UploadImage';
 import { isNil } from 'utils/index';
 import { useUpdateTodoTask } from 'hooks/queries/task/useUpdateTodoTask';
 import { isAos } from 'utils/device';
+import { useFetchTodoTask } from 'hooks/queries/task/useFetchTodoTask';
+import { useFetchDowithTask } from 'hooks/queries/task/useFetchDowithTask';
 
 dayjs.extend(customParseFormat);
 
@@ -58,6 +60,22 @@ const Item = ({
   const isDisabled = status === TASK_STATUS_ENUM.enum.FAIL;
 
   const { mutate: completeTodoTaskMutate } = useUpdateTodoTask({ year, month });
+  const { data: todoTaskData } = useFetchTodoTask({ todoTaskId: id }, { enabled: mode === 'TODO' && id !== -1 });
+  const { data: dowithTaskData } = useFetchDowithTask(
+    { dowithTaskId: id },
+    { enabled: mode === 'DOWITH' && id !== -1 },
+  );
+
+  const data = id && mode ? todoTaskData ?? dowithTaskData : null;
+  const isRoutineTask = !isNil(data?.routineCondition);
+
+  const getSnapPoints = () => {
+    if (!isRoutineTask) {
+      return [isAos ? '25%' : '23%'];
+    }
+
+    return [isAos ? '31%' : '29%'];
+  };
 
   const handleBottomSheet = () => {
     taskManagementBottomSheetModalRef.current?.present();
@@ -84,7 +102,7 @@ const Item = ({
   };
 
   const handleTodoTaskStatus = (mode: TaskModeType, id: number, status: TaskStatusEnumType) => () => {
-    // TODO task가 아니거나 상태가 실패면 무시
+    // task가 아니거나 상태가 실패면 무시
     if (mode === 'DOWITH' || status === 'FAIL') {
       return;
     }
@@ -161,16 +179,18 @@ const Item = ({
           </View>
         </View>
       </View>
-      <BottomSheet ref={taskManagementBottomSheetModalRef} title="투두 관리하기" snapPoints={[isAos ? '31%' : '29%']}>
+      <BottomSheet ref={taskManagementBottomSheetModalRef} title="투두 관리하기" snapPoints={getSnapPoints()}>
         <View style={styles.modalContainer}>
           <Pressable style={styles.modalContentRow} onPress={handleEditTask}>
             <TaskEdit />
             <Text style={styles.modalContentText}>할 일 수정하기</Text>
           </Pressable>
-          <View style={styles.modalContentRow}>
-            <RoutineEdit />
-            <Text style={styles.modalContentText}>루틴 수정하기</Text>
-          </View>
+          {isRoutineTask ? (
+            <View style={styles.modalContentRow}>
+              <RoutineEdit />
+              <Text style={styles.modalContentText}>루틴 수정하기</Text>
+            </View>
+          ) : null}
           <View style={styles.modalContentRow}>
             <TaskDelete />
             <Text style={styles.modalContentText}>삭제하기</Text>

--- a/src/components/Task/List/index.tsx
+++ b/src/components/Task/List/index.tsx
@@ -10,9 +10,10 @@ interface Props {
   items: dowithTaskSchemeType[] | todoTaskSchemeType[];
   year: number;
   month: number;
+  selectedDate: string;
 }
 
-const List = ({ type, items, year, month }: Props) => {
+const List = ({ type, items, year, month, selectedDate }: Props) => {
   const isDoWithMode = type === 'DOWITH';
 
   return (
@@ -33,7 +34,15 @@ const List = ({ type, items, year, month }: Props) => {
         </Text>
       </View>
       {items.map(({ id, ...rest }) => (
-        <Item key={id} id={id} mode={isDoWithMode ? 'DOWITH' : 'TODO'} year={year} month={month} {...rest} />
+        <Item
+          key={id}
+          id={id}
+          mode={isDoWithMode ? 'DOWITH' : 'TODO'}
+          year={year}
+          month={month}
+          selectedDate={selectedDate}
+          {...rest}
+        />
       ))}
     </View>
   );

--- a/src/components/Task/ListContainerView/index.tsx
+++ b/src/components/Task/ListContainerView/index.tsx
@@ -4,152 +4,17 @@ import { ScrollView } from 'react-native';
 import { List } from 'components/Task';
 import type { fetchTaskListResponseSchemeDataType } from 'types/task/scheme/api';
 
-// NOTE: 임시 Mock Data
-// const MOCK_DATA = {
-//   todoTasks: [
-//     {
-//       id: 1,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기 todo',
-//       status: 'WAIT',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//     },
-//     {
-//       id: 2,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기 todo',
-//       status: 'SUCCESS',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//     },
-//   ],
-//   dowithTasks: [
-//     {
-//       id: 1,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기 dowith',
-//       status: 'WAIT',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       confirmedImageUrl: '',
-//       feedBackCount: 5,
-//     },
-//     {
-//       id: 2,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기2222',
-//       status: 'SUCCESS',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       confirmedImageUrl: 'https://media.bunjang.co.kr/images/crop/981758465_w320.jpg',
-//       feedBackCount: 5,
-//     },
-//     {
-//       id: 3,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기3333',
-//       status: 'FAIL',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       // confirmedImageUrl: 'https://example.com/image.jpg',
-//       feedBackCount: 5,
-//     },
-//     {
-//       id: 4,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기3333',
-//       status: 'FAIL',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       // confirmedImageUrl: 'https://example.com/image.jpg',
-//       feedBackCount: 5,
-//     },
-//     {
-//       id: 5,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기3333',
-//       status: 'FAIL',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       // confirmedImageUrl: 'https://example.com/image.jpg',
-//       feedBackCount: 5,
-//     },
-//     {
-//       id: 6,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기3333',
-//       status: 'FAIL',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       // confirmedImageUrl: 'https://example.com/image.jpg',
-//       feedBackCount: 5,
-//     },
-//     {
-//       id: 7,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기3333',
-//       status: 'FAIL',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       // confirmedImageUrl: 'https://example.com/image.jpg',
-//       feedBackCount: 5,
-//     },
-//     {
-//       id: 8,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기3333',
-//       status: 'FAIL',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       // confirmedImageUrl: 'https://example.com/image.jpg',
-//       feedBackCount: 5,
-//     },
-//     {
-//       id: 9,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기3333',
-//       status: 'FAIL',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       // confirmedImageUrl: 'https://example.com/image.jpg',
-//       feedBackCount: 5,
-//     },
-//     {
-//       id: 10,
-//       taskCategoryId: 2,
-//       taskCategoryName: '일상',
-//       title: '아침 먹기3333',
-//       status: 'FAIL',
-//       date: '2025-06-07',
-//       startTime: '15:00:00',
-//       // confirmedImageUrl: 'https://example.com/image.jpg',
-//       feedBackCount: 5,
-//     },
-//   ],
-// };
-
 interface Props {
   year: number;
   month: number;
   taskList: fetchTaskListResponseSchemeDataType;
+  selectedDate: string;
 }
 
-const ListContainerView = ({ year, month, taskList }: Props) => (
+const ListContainerView = ({ year, month, taskList, selectedDate }: Props) => (
   <ScrollView contentContainerStyle={{ paddingBottom: 134, gap: 16 }} showsVerticalScrollIndicator={false}>
-    <List type="DOWITH" items={taskList.dowithTasks} year={year} month={month} />
-    <List type="TODO" items={taskList.todoTasks} year={year} month={month} />
+    <List type="DOWITH" items={taskList.dowithTasks} year={year} month={month} selectedDate={selectedDate} />
+    <List type="TODO" items={taskList.todoTasks} year={year} month={month} selectedDate={selectedDate} />
   </ScrollView>
 );
 

--- a/src/components/navigators/Stack/Task/index.tsx
+++ b/src/components/navigators/Stack/Task/index.tsx
@@ -2,22 +2,26 @@ import { createStackNavigator } from '@react-navigation/stack';
 
 import { Form } from 'components/Task';
 import { theme } from 'styles/theme';
-import type { TaskFormStackParamList } from 'types/shared';
+import type { TaskFormStackParamList, TaskModeType } from 'types/shared';
 
-const TaskFormStackNavigator = () => {
+interface Props {
+  mode?: TaskModeType;
+}
+
+const TaskFormStackNavigator = ({ mode }: Props) => {
   const { Navigator, Screen } = createStackNavigator<TaskFormStackParamList>();
   return (
     <Navigator
       initialRouteName="FORM"
       screenOptions={{
-        headerTitle: '할 일 추가하기',
+        headerTitle: `할 일 ${mode ? '수정' : '추가'}하기`,
         headerTitleAlign: 'center',
         headerBackTitleVisible: false,
         headerTintColor: theme.COLORS.DEFAULT.BLACK,
         cardStyle: { backgroundColor: theme.COLORS.DEFAULT.WHITE },
       }}
     >
-      <Screen name="FORM" component={Form} />
+      <Screen name="FORM" component={Form} initialParams={{ mode }} />
     </Navigator>
   );
 };

--- a/src/hooks/queries/task/useFetchDowithTask.ts
+++ b/src/hooks/queries/task/useFetchDowithTask.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { TASK_QUERY_KEY } from 'constants/queries';
 import { fetchDowithTask } from 'services/rest/task';
@@ -9,11 +9,18 @@ import type {
   fetchDowithTaskResponseSchemeType,
 } from 'types/task/scheme/api';
 
-const useFetchDowithTask = ({ dowithTaskId }: fetchDowithTaskRequestSchemeType) =>
+const useFetchDowithTask = (
+  { dowithTaskId }: fetchDowithTaskRequestSchemeType,
+  options?: Omit<
+    UseQueryOptions<fetchDowithTaskResponseSchemeType, AxiosError, addTaskRequestSchemeType>,
+    'queryKey' | 'queryFn'
+  >,
+) =>
   useQuery<fetchDowithTaskResponseSchemeType, AxiosError, addTaskRequestSchemeType>({
-    queryKey: [...TASK_QUERY_KEY.LIST, dowithTaskId],
+    queryKey: [...TASK_QUERY_KEY.LIST, 'dowith', dowithTaskId],
     queryFn: () => fetchDowithTask({ dowithTaskId }),
     select: data => data.data,
+    ...options,
   });
 
 export { useFetchDowithTask };

--- a/src/hooks/queries/task/useFetchTodoTask.ts
+++ b/src/hooks/queries/task/useFetchTodoTask.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { TASK_QUERY_KEY } from 'constants/queries';
 import { fetchTodoTask } from 'services/rest/task';
@@ -9,11 +9,18 @@ import type {
   fetchTodoTaskResponseSchemeType,
 } from 'types/task/scheme/api';
 
-const useFetchTodoTask = ({ todoTaskId }: fetchTodoTaskRequestSchemeType) =>
+const useFetchTodoTask = (
+  { todoTaskId }: fetchTodoTaskRequestSchemeType,
+  options?: Omit<
+    UseQueryOptions<fetchTodoTaskResponseSchemeType, AxiosError, fetchTodoTaskResponseDataSchemeType>,
+    'queryKey' | 'queryFn'
+  >,
+) =>
   useQuery<fetchTodoTaskResponseSchemeType, AxiosError, fetchTodoTaskResponseDataSchemeType>({
-    queryKey: [...TASK_QUERY_KEY.LIST, todoTaskId],
+    queryKey: [...TASK_QUERY_KEY.LIST, 'todo', todoTaskId],
     queryFn: () => fetchTodoTask({ todoTaskId }),
     select: data => data.data,
+    ...options,
   });
 
 export { useFetchTodoTask };

--- a/src/hooks/queries/task/useUpdateTodoTaskStatus.ts
+++ b/src/hooks/queries/task/useUpdateTodoTaskStatus.ts
@@ -11,7 +11,7 @@ interface Props {
   month: number;
 }
 
-const useUpdateTodoTask = ({ year, month }: Props) => {
+const useUpdateTodoTaskStatus = ({ year, month }: Props) => {
   const queryClient = useQueryClient();
 
   return useMutation<updateTodoTaskResponseSchemeType, AxiosError, { id: number; status: TaskStatusEnumType }>({
@@ -23,4 +23,4 @@ const useUpdateTodoTask = ({ year, month }: Props) => {
   });
 };
 
-export { useUpdateTodoTask };
+export { useUpdateTodoTaskStatus };

--- a/src/screens/Home/Task/Form/index.tsx
+++ b/src/screens/Home/Task/Form/index.tsx
@@ -3,31 +3,42 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { TaskFormStackNavigator } from 'components/navigators/Stack/Task';
 import type { addTaskRequestSchemeType } from 'types/task/scheme/api';
 import type { RootStackScreenProps } from 'types/shared';
+import { useFetchTodoTask } from 'hooks/queries/task/useFetchTodoTask';
+import { useFetchDowithTask } from 'hooks/queries/task/useFetchDowithTask';
 
 const TaskForm = ({
   route: {
-    params: { date },
+    params: { date, id = -1, mode },
   },
 }: RootStackScreenProps<'TASK_FORM'>) => {
+  const { data: todoTaskData } = useFetchTodoTask({ todoTaskId: id }, { enabled: mode === 'TODO' && id !== -1 });
+  const { data: dowithTaskData } = useFetchDowithTask(
+    { dowithTaskId: id },
+    { enabled: mode === 'DOWITH' && id !== -1 },
+  );
+
+  const data = id && mode ? todoTaskData ?? dowithTaskData : null;
   const methods = useForm<addTaskRequestSchemeType>({
     defaultValues: {
-      title: '',
-      taskCategoryId: null,
-      date,
-      startTime: null,
-      routineCondition: {
-        startDate: undefined,
-        endDate: undefined,
-        cycle: undefined,
-        pattern: [],
-        isExcludeHolidays: false,
-      },
+      title: data ? data.title : '',
+      taskCategoryId: data ? data.taskCategoryId : null,
+      date: data ? data.date : date,
+      startTime: data ? data.startTime : null,
+      routineCondition: data
+        ? data.routineCondition
+        : {
+            startDate: undefined,
+            endDate: undefined,
+            cycle: undefined,
+            pattern: [],
+            isExcludeHolidays: false,
+          },
     },
   });
 
   return (
     <FormProvider {...methods}>
-      <TaskFormStackNavigator />
+      <TaskFormStackNavigator mode={mode} />
     </FormProvider>
   );
 };

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -338,7 +338,12 @@ const Home = ({ navigation: { navigate } }: HomeTabScreenProps<'MYTODO'>) => {
                   </View>
                   {selectedDateTaskList ? (
                     <View style={{ flex: 1, marginTop: 16 }}>
-                      <ListContainerView year={year} month={month} taskList={selectedDateTaskList} />
+                      <ListContainerView
+                        year={year}
+                        month={month}
+                        taskList={selectedDateTaskList}
+                        selectedDate={selectedDate}
+                      />
                     </View>
                   ) : null}
                 </View>

--- a/src/types/shared/index.ts
+++ b/src/types/shared/index.ts
@@ -14,6 +14,8 @@ type RootStackParamList = {
   SETTING: undefined;
   TASK_FORM: {
     date: string;
+    id?: number;
+    mode?: TaskModeType;
   };
   FEEDBACK: undefined;
 };
@@ -34,7 +36,9 @@ type HomeTabScreenProps<T extends keyof HomeTabParamList> = CompositeScreenProps
 type TaskModeType = 'TODO' | 'DOWITH';
 
 type TaskFormStackParamList = {
-  FORM: undefined;
+  FORM: {
+    mode?: TaskModeType;
+  };
 };
 
 type TaskFormStackScreenProps<T extends keyof TaskFormStackParamList> = StackScreenProps<TaskFormStackParamList, T>;


### PR DESCRIPTION
## 🤔 개요
Task 수정하기 페이지 화면 구현이 필요함

## 📝 작업 내용
1. Task 수정하기 페이지 화면 구현
2. 루틴 task가 아닐 경우 투두 관리하기 바텀 시트에서 루틴 수정하기 버튼 미노출 처리
3. 투두 task 상태 업데이트 hooks 이름 수정

## 📸 작업 화면
<table>
<tr>
<td>🤖 AOS</td>
<td>🍎 IOS</td>
</tr>
<tr>
<td>

<img width="354" height="770" alt="스크린샷 2025-10-25 오후 8 14 42" src="https://github.com/user-attachments/assets/d9c5286b-b9b8-4810-8f50-6a85645a8db6" />
</td>
<td>

<img width="371" height="800" alt="스크린샷 2025-10-25 오후 8 14 32" src="https://github.com/user-attachments/assets/86bea089-bb8a-44bb-980b-dce02936b7db" />
</td>
</tr>
</table>

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-497](https://www.notion.so/28adf3a3e43f8007ab17f57447795f88?v=72865a96132e456c873537e8de4c3757&source=copy_link)