### PR TITLE
[TAS-430, 431, 514, 515, 516, 519]add: Task 수정 API(루틴 포함) 및 루틴 수정/삭제 API 연동, 기타 작업

### DIFF
--- a/src/components/Task/Form/Common/index.tsx
+++ b/src/components/Task/Form/Common/index.tsx
@@ -19,7 +19,7 @@ import type { addTaskRequestSchemeType } from 'types/task/scheme/api';
 import { useAddDowithTask } from 'hooks/queries/task/useAddDowithTask';
 import { isNil } from 'utils/index';
 import { StackScreenProps } from '@react-navigation/stack';
-import { useUpdateTodoTask } from 'hooks/queries/task/useUpdateTodoTask';
+import { useUpdateTask } from 'hooks/queries/task/useUpdateTask';
 import { useDialog } from 'components/common/Dialog/Provider';
 
 const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'COMMON'>) => {
@@ -39,11 +39,14 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
 
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
   const [taskMode, setTaskMode] = useState<TaskModeType | null>(params.mode ?? null);
+  const isTodoMode = taskMode === 'TODO';
+
   const { data: taskCategoryList } = useFetchTaskCategoryList();
   const { mutate: addTodoTaskMutate, isPending: isAddTodoTaskMutateLoading } = useAddTodoTask();
-  const { mutate: updateTodoTaskMutate, isPending: isUpdateTodoTaskMutateLoading } = useUpdateTodoTask({
+  const { mutate: updateTaskMutate, isPending: isUpdateTaskMutateLoading } = useUpdateTask({
     type: 'EDIT',
     id: params.id,
+    mode: isTodoMode ? 'TODO' : 'DOWITH',
     isRoutineTask,
   });
   const { mutate: addDowithTaskMutate, isPending: isAddDowithTaskMutateLoading } = useAddDowithTask();
@@ -54,10 +57,9 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
   const taskCategoryId = watch('taskCategoryId');
   const routineCondition = watch('routineCondition');
 
-  const isTodoMode = taskMode === 'TODO';
   const isFormDisabled = taskMode === null;
   const isButtonDisabled = isTodoMode
-    ? !isFieldChanged || !title || isAddTodoTaskMutateLoading || isUpdateTodoTaskMutateLoading
+    ? !isFieldChanged || !title || isAddTodoTaskMutateLoading || isUpdateTaskMutateLoading
     : !isFieldChanged || !title || !startTime || isAddDowithTaskMutateLoading;
   const prevSelectedCategory = taskCategoryList?.find(({ id }) => taskCategoryId === id);
 
@@ -202,32 +204,32 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
       };
 
       const handleButton = () => {
-        updateTodoTaskMutate(payload);
+        updateTaskMutate(payload);
         hideDialog();
       };
 
       console.log(payload);
-      if (isTodoMode) {
-        if (isEditMode) {
-          // 루틴이 설정되어 있는 투두 Task 일 때
-          if (isRoutineTask) {
-            showDialog({
-              title: `루틴 ${isTodoMode ? '투두' : '두윗'} 수정하기`,
-              content: `루틴으로 수정한 앞으로의 ${isTodoMode ? '투두를' : '두윗을'}\n모두 수정하시겠어요?`,
-              leftButtonText: '모두 수정하기',
-              rightButtonText: '이번만 수정하기',
-              handleLeftButton: handleButton,
-              handleRightButton: handleButton,
-            });
-          }
-          updateTodoTaskMutate(payload);
-          return;
+      if (isEditMode) {
+        // 루틴이 설정되어 있는 투두 Task 일 때
+        if (isRoutineTask) {
+          showDialog({
+            title: `루틴 ${isTodoMode ? '투두' : '두윗'} 수정하기`,
+            content: `루틴으로 수정한 앞으로의 ${isTodoMode ? '투두를' : '두윗을'}\n모두 수정하시겠어요?`,
+            leftButtonText: '모두 수정하기',
+            rightButtonText: '이번만 수정하기',
+            handleLeftButton: handleButton,
+            handleRightButton: handleButton,
+          });
         }
+        updateTaskMutate(payload);
+        return;
+      }
+
+      if (isTodoMode) {
         addTodoTaskMutate(payload);
         return;
       }
 
-      // TODO: 두윗 모드 수정 API 연동
       addDowithTaskMutate(payload);
     },
     [isTodoMode, isEditMode, isRoutineTask],
@@ -356,7 +358,7 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
             style={[
               theme.TYPOGRAPHY.TITLE_2,
               { color: theme.COLORS.DEFAULT.WHITE },
-              (isAddTodoTaskMutateLoading || isUpdateTodoTaskMutateLoading || isAddDowithTaskMutateLoading) && {
+              (isAddTodoTaskMutateLoading || isUpdateTaskMutateLoading || isAddDowithTaskMutateLoading) && {
                 backgroundColor: theme.COLORS.GRAY_SCALE.GRAY_80,
               },
             ]}

--- a/src/components/Task/Form/Common/index.tsx
+++ b/src/components/Task/Form/Common/index.tsx
@@ -20,10 +20,13 @@ import { useAddDowithTask } from 'hooks/queries/task/useAddDowithTask';
 import { isNil } from 'utils/index';
 import { StackScreenProps } from '@react-navigation/stack';
 import { useUpdateTodoTask } from 'hooks/queries/task/useUpdateTodoTask';
+import { useDialog } from 'components/common/Dialog/Provider';
 
 const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'COMMON'>) => {
   const { params } = route;
   const isEditMode = !!params.mode;
+  const isRoutineTask = params.isRoutineTask;
+  const { showDialog, hideDialog } = useDialog();
   const {
     control,
     watch,
@@ -41,6 +44,7 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
   const { mutate: updateTodoTaskMutate, isPending: isUpdateTodoTaskMutateLoading } = useUpdateTodoTask({
     type: 'EDIT',
     id: params.id,
+    isRoutineTask,
   });
   const { mutate: addDowithTaskMutate, isPending: isAddDowithTaskMutateLoading } = useAddDowithTask();
   const isFieldChanged = Object.keys(dirtyFields).length > 0;
@@ -197,9 +201,25 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
         ...(isNil(values.routineCondition?.startDate) && { routineCondition: null }),
       };
 
+      const handleButton = () => {
+        updateTodoTaskMutate(payload);
+        hideDialog();
+      };
+
       console.log(payload);
       if (isTodoMode) {
         if (isEditMode) {
+          // 루틴이 설정되어 있는 투두 Task 일 때
+          if (isRoutineTask) {
+            showDialog({
+              title: `루틴 ${isTodoMode ? '투두' : '두윗'} 수정하기`,
+              content: `루틴으로 수정한 앞으로의 ${isTodoMode ? '투두를' : '두윗을'}\n모두 수정하시겠어요?`,
+              leftButtonText: '모두 수정하기',
+              rightButtonText: '이번만 수정하기',
+              handleLeftButton: handleButton,
+              handleRightButton: handleButton,
+            });
+          }
           updateTodoTaskMutate(payload);
           return;
         }
@@ -210,7 +230,7 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
       // TODO: 두윗 모드 수정 API 연동
       addDowithTaskMutate(payload);
     },
-    [isTodoMode, isEditMode],
+    [isTodoMode, isEditMode, isRoutineTask],
   );
 
   return (
@@ -226,7 +246,7 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
                 >
                   제목
                 </Text>
-                <Text style={isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }}>{title.length}/40</Text>
+                <Text style={isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }}>{title.length}/20</Text>
               </View>
               <Controller
                 name="title"
@@ -242,7 +262,7 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
                       onChange(value);
                     }}
                     value={value}
-                    maxLength={40}
+                    maxLength={20}
                     editable={!isFormDisabled}
                   />
                 )}
@@ -349,6 +369,7 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
         modal
         open={datePickerOpen}
         mode="time"
+        minimumDate={!isTodoMode ? new Date() : undefined}
         minuteInterval={5}
         locale="ko-KR"
         date={startTime ? dayjs(startTime, 'HH:mm:ss').toDate() : dayjs().toDate()}

--- a/src/components/Task/Form/Common/index.tsx
+++ b/src/components/Task/Form/Common/index.tsx
@@ -290,63 +290,51 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
                 {startTime ? dayjs(startTime, 'HH:mm:ss').format('HH:mm') : '미등록'}
               </Text>
             </Pressable>
-            <Controller
-              name="taskCategoryId"
-              control={control}
-              render={() => (
-                <Pressable
-                  style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
-                  onPress={handlePresentModalPress}
-                >
-                  <View style={styles.optionalLabelWrap}>
-                    <Text
-                      style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}
-                    >
-                      카테고리
-                    </Text>
-                    <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>
-                      (선택)
-                    </Text>
-                  </View>
-                  <Text style={[styles.emptyValue, taskCategoryId !== null && styles.value]}>
-                    {prevSelectedCategory ? prevSelectedCategory.title : '미등록'}
-                  </Text>
-                </Pressable>
-              )}
-            />
-            {!isEditMode ? (
-              <Pressable
-                style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
-                onPress={handleTaskRoutine}
-              >
-                <View
-                  style={{ flex: 1, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' }}
-                >
-                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                    <Text
-                      style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}
-                    >
-                      루틴 설정
-                    </Text>
-                    <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>
-                      (선택)
-                    </Text>
-                  </View>
-                </View>
+            <Pressable
+              style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
+              onPress={handlePresentModalPress}
+            >
+              <View style={styles.optionalLabelWrap}>
                 <Text
-                  style={[
-                    theme.TYPOGRAPHY.BODY_2,
-                    { color: routineCondition?.cycle ? theme.COLORS.DEFAULT.BLACK : theme.COLORS.GRAY_SCALE.GRAY_80 },
-                  ]}
+                  style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}
                 >
-                  {routineCondition?.cycle
-                    ? `${dayjs(routineCondition?.startDate).format('YYYY. MM. DD')} ~ ${dayjs(
-                        routineCondition?.endDate,
-                      ).format('YYYY. MM. DD')}`
-                    : '미등록'}
+                  카테고리
                 </Text>
-              </Pressable>
-            ) : null}
+                <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>
+                  (선택)
+                </Text>
+              </View>
+              <Text style={[styles.emptyValue, taskCategoryId !== null && styles.value]}>
+                {prevSelectedCategory ? prevSelectedCategory.title : '미등록'}
+              </Text>
+            </Pressable>
+            <Pressable
+              style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
+              onPress={handleTaskRoutine}
+            >
+              <View
+                style={{ flex: 1, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' }}
+              >
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                  <Text
+                    style={[theme.TYPOGRAPHY.SUB_TITLE, isFormDisabled && { color: theme.COLORS.GRAY_SCALE.GRAY_80 }]}
+                  >
+                    루틴 설정
+                  </Text>
+                  <Text style={[theme.TYPOGRAPHY.CAPTION1_BASIC, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>
+                    (선택)
+                  </Text>
+                </View>
+              </View>
+              <Text
+                style={[
+                  theme.TYPOGRAPHY.BODY_2,
+                  { color: routineCondition?.cycle ? theme.COLORS.DEFAULT.BLACK : theme.COLORS.GRAY_SCALE.GRAY_80 },
+                ]}
+              >
+                {routineCondition?.cycle ? '등록 완료' : '미등록'}
+              </Text>
+            </Pressable>
           </View>
         </View>
         <Pressable

--- a/src/components/Task/Form/Common/index.tsx
+++ b/src/components/Task/Form/Common/index.tsx
@@ -53,6 +53,7 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
   const isFieldChanged = Object.keys(dirtyFields).length > 0;
 
   const title = watch('title');
+  const date = watch('date');
   const startTime = watch('startTime');
   const taskCategoryId = watch('taskCategoryId');
   const routineCondition = watch('routineCondition');
@@ -183,9 +184,21 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
 
   const handleTaskMode = useCallback(
     (mode: TaskModeType) => () => {
+      // 지난 날짜에는 두윗 등록 불가
+      const isInvalidAddDowithTask = !isTodoMode && dayjs(date).isBefore(dayjs(), 'day');
+      if (isInvalidAddDowithTask) {
+        showDialog({
+          type: 'ALERT',
+          title: '두윗 등록 불가',
+          content:
+            '지난 날짜에는 두윗을 등록할 수 없어요.\n\n다른 두윗들에게 잔소리를 받으려면\n미래 날짜에 두윗을 등록해 주세요!',
+          handleAlertButton: hideDialog,
+        });
+        return;
+      }
       setTaskMode(mode);
     },
-    [],
+    [isTodoMode, date],
   );
 
   const handleTaskRoutine = useCallback(() => {

--- a/src/components/Task/Form/Routine/index.tsx
+++ b/src/components/Task/Form/Routine/index.tsx
@@ -222,8 +222,8 @@ const RoutineForm = forwardRef<RoutineFormRefMethod, Props>(
 
     const initRoutineCondition = (data?: fetchTodoTaskResponseDataSchemeType | addTaskRequestSchemeType | null) => {
       const getSelectedDaySet = (type: Exclude<TaskRoutineCycleEnumType, 'DAILY'>) => {
-        const cycle = data?.routineCondition?.cycle;
-        if (!data || cycle === TASK_ROUTINE_CYCLE_ENUM.enum.DAILY) {
+        const cycle = data?.routineCondition?.cycle ?? routineCondition?.cycle;
+        if (!cycle || cycle === TASK_ROUTINE_CYCLE_ENUM.enum.DAILY) {
           return new Set<number>();
         }
 
@@ -234,22 +234,20 @@ const RoutineForm = forwardRef<RoutineFormRefMethod, Props>(
         return new Set<number>();
       };
 
-      // TODO: 투두 생성 시, 루틴을 이미 설정해서 저장해놓았다면 해당 상태로 초기화 필요
-
-      setSelectedStartDate(data?.routineCondition?.startDate ?? null);
-      setSelectedEndDate(data?.routineCondition?.endDate ?? null);
-      setIsExcludeHolidays(data?.routineCondition?.isExcludeHolidays ?? false);
-      setSelectedPrimaryCategory(data?.routineCondition?.cycle ?? null);
+      setSelectedStartDate(data?.routineCondition?.startDate ?? routineCondition?.startDate ?? null);
+      setSelectedEndDate(data?.routineCondition?.endDate ?? routineCondition?.endDate ?? null);
+      setIsExcludeHolidays(data?.routineCondition?.isExcludeHolidays ?? routineCondition?.isExcludeHolidays ?? false);
+      setSelectedPrimaryCategory(data?.routineCondition?.cycle ?? routineCondition?.cycle ?? null);
       setSelectedWeeklyDaySet(getSelectedDaySet(TASK_ROUTINE_CYCLE_ENUM.enum.WEEKLY));
       setSelectedMonthlyDaySet(getSelectedDaySet(TASK_ROUTINE_CYCLE_ENUM.enum.MONTHLY));
       setExpanded(true);
 
       setValue('routineCondition', {
-        startDate: data?.routineCondition?.startDate ?? null,
-        endDate: data?.routineCondition?.endDate ?? null,
-        cycle: data?.routineCondition?.cycle ?? null,
-        pattern: data?.routineCondition?.pattern ?? [],
-        isExcludeHolidays: data?.routineCondition?.isExcludeHolidays ?? false,
+        startDate: data?.routineCondition?.startDate ?? routineCondition?.startDate ?? null,
+        endDate: data?.routineCondition?.endDate ?? routineCondition?.endDate ?? null,
+        cycle: data?.routineCondition?.cycle ?? routineCondition?.cycle ?? null,
+        pattern: data?.routineCondition?.pattern ?? routineCondition?.pattern ?? [],
+        isExcludeHolidays: data?.routineCondition?.isExcludeHolidays ?? routineCondition?.isExcludeHolidays ?? false,
       });
     };
 
@@ -350,13 +348,7 @@ const RoutineForm = forwardRef<RoutineFormRefMethod, Props>(
       closeBottomSheet();
     };
 
-    const handleExpanded = () => {
-      if (expanded) {
-        setSelectedStartDate(null);
-        setSelectedEndDate(null);
-      }
-      setExpanded(!expanded);
-    };
+    const handleExpanded = () => setExpanded(!expanded);
 
     const handlePrimaryCategory = (value: TaskRoutineCycleEnumType) => () => {
       // 선택한 반복 패턴이 매 주가 아닐 경우 선택한 요일 Set 초기화

--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -25,7 +25,7 @@ import { useUpdateTodoTaskStatus } from 'hooks/queries/task/useUpdateTodoTaskSta
 import { isAos } from 'utils/device';
 import { useFetchTodoTask } from 'hooks/queries/task/useFetchTodoTask';
 import { useFetchDowithTask } from 'hooks/queries/task/useFetchDowithTask';
-import { useUpdateTodoTask } from 'hooks/queries/task/useUpdateTodoTask';
+import { useUpdateTask } from 'hooks/queries/task/useUpdateTask';
 import { useDialog } from 'components/common/Dialog/Provider';
 
 dayjs.extend(customParseFormat);
@@ -70,9 +70,10 @@ const Item = ({
   const isDisabled = status === TASK_STATUS_ENUM.enum.FAIL;
 
   const { mutate: completeTodoTaskStatusMutate } = useUpdateTodoTaskStatus({ year, month });
-  const { mutate: deleteTodoTaskMutate } = useUpdateTodoTask({
+  const { mutate: deleteTaskMutate } = useUpdateTask({
     type: 'DELETE',
     id,
+    mode: isTodoMode ? 'TODO' : 'DOWITH',
     isRoutineTask,
     year,
     month,
@@ -151,10 +152,7 @@ const Item = ({
             rightButtonText: '삭제',
             handleLeftButton: hideDialog,
             handleRightButton: () => {
-              if (isTodoMode) {
-                deleteTodoTaskMutate(undefined);
-              }
-              // TODO: 두윗 삭제하기 API 연동 필요
+              deleteTaskMutate(undefined);
               hideDialog();
             },
           });

--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -60,23 +60,23 @@ const Item = ({
   const { navigate } = useNavigation<StackNavigationProp<RootStackParamList>>();
   const { showDialog, hideDialog } = useDialog();
   const taskManagementBottomSheetModalRef = useRef<BottomSheetModal>(null);
+  const isTodoMode = mode === 'TODO';
+
+  const { data: todoTaskData } = useFetchTodoTask({ todoTaskId: id }, { enabled: mode === 'TODO' && id !== -1 });
+  const { data: dowithTaskData } = useFetchDowithTask({ dowithTaskId: id }, { enabled: !isTodoMode && id !== -1 });
+
+  const data = id && mode ? todoTaskData ?? dowithTaskData : null;
+  const isRoutineTask = !isNil(data?.routineCondition);
   const isDisabled = status === TASK_STATUS_ENUM.enum.FAIL;
 
   const { mutate: completeTodoTaskStatusMutate } = useUpdateTodoTaskStatus({ year, month });
   const { mutate: deleteTodoTaskMutate } = useUpdateTodoTask({
     type: 'DELETE',
     id,
+    isRoutineTask,
     year,
     month,
   });
-  const { data: todoTaskData } = useFetchTodoTask({ todoTaskId: id }, { enabled: mode === 'TODO' && id !== -1 });
-  const { data: dowithTaskData } = useFetchDowithTask(
-    { dowithTaskId: id },
-    { enabled: mode === 'DOWITH' && id !== -1 },
-  );
-
-  const data = id && mode ? todoTaskData ?? dowithTaskData : null;
-  const isRoutineTask = !isNil(data?.routineCondition);
 
   const getSnapPoints = () => {
     if (!isRoutineTask) {
@@ -93,7 +93,7 @@ const Item = ({
   const renderTaskStatusIcon = (mode: TaskModeType, status: TaskStatusEnumType) => {
     switch (status) {
       case TASK_STATUS_ENUM.enum.WAIT:
-        if (mode === 'DOWITH') {
+        if (!isTodoMode) {
           return <UploadImage />;
         }
 
@@ -112,32 +112,49 @@ const Item = ({
 
   const handleTodoTaskStatus = (mode: TaskModeType, id: number, status: TaskStatusEnumType) => () => {
     // task가 아니거나 상태가 실패면 무시
-    if (mode === 'DOWITH' || status === 'FAIL') {
+    if (!isTodoMode || status === 'FAIL') {
       return;
     }
 
     completeTodoTaskStatusMutate({ id, status });
   };
 
-  const handleEditTask =
-    ({ type, isRoutine = false }: { type: 'EDIT' | 'DELETE'; isRoutine?: boolean }) =>
+  const handleTask =
+    ({ type, isRoutineTask }: { type: 'EDIT' | 'EDIT_ROUTINE' | 'DELETE'; isRoutineTask: boolean }) =>
     () => {
-      // 루틴 수정하기 버튼을 눌렀을 때,
-      if (isRoutine) {
-        navigate('TASK_FORM', { date: selectedDate, id, mode, screen: 'ROUTINE' });
-      } else {
-        const isEditType = type === 'EDIT';
-        if (isEditType) {
-          navigate('TASK_FORM', { date: selectedDate, id, mode, screen: 'COMMON' });
+      // 할일 수정하기 버튼을 눌렀을 때
+      if (type === 'EDIT') {
+        navigate('TASK_FORM', { date: selectedDate, id, mode, screen: 'COMMON', isRoutineTask });
+      }
+
+      // 루틴 수정하기 버튼을 눌렀을 때
+      if (type === 'EDIT_ROUTINE') {
+        navigate('TASK_FORM', { date: selectedDate, id, mode, screen: 'ROUTINE', isRoutineTask });
+      }
+
+      // 삭제하기 버튼을 눌렀을 때
+      if (type === 'DELETE') {
+        // 현재 시간이 삭제하려는 두윗 등록 시간보다 같거나 이후일 경우 삭제 불가 팝업 노출
+        const isInvalidDeleteTask = dayjs(`${data?.date} ${data?.startTime}`).isSameOrBefore(dayjs());
+        if (!isTodoMode && isInvalidDeleteTask) {
+          showDialog({
+            type: 'ALERT',
+            title: '두윗모드 삭제 불가',
+            content: '시작 시간이 지난 두윗모드는\n삭제할 수 없어요.',
+            handleAlertButton: hideDialog,
+          });
         } else {
           showDialog({
-            title: '투두 삭제하기',
-            content: '등록한 투두를 삭제하시겠어요?',
+            title: `${isTodoMode ? '투두' : '두윗'} 삭제하기`,
+            content: `등록한 ${isTodoMode ? '투두를' : '두윗을'} 삭제하시겠어요?`,
             leftButtonText: '취소',
             rightButtonText: '삭제',
             handleLeftButton: hideDialog,
             handleRightButton: () => {
-              deleteTodoTaskMutate(undefined);
+              if (isTodoMode) {
+                deleteTodoTaskMutate(undefined);
+              }
+              // TODO: 두윗 삭제하기 API 연동 필요
               hideDialog();
             },
           });
@@ -210,19 +227,23 @@ const Item = ({
           </View>
         </View>
       </View>
-      <BottomSheet ref={taskManagementBottomSheetModalRef} title="투두 관리하기" snapPoints={getSnapPoints()}>
+      <BottomSheet
+        ref={taskManagementBottomSheetModalRef}
+        title={`${isTodoMode ? 'TO DO' : 'DO WITH'} 관리하기`}
+        snapPoints={getSnapPoints()}
+      >
         <View style={styles.modalContainer}>
-          <Pressable style={styles.modalContentRow} onPress={handleEditTask({ type: 'EDIT' })}>
+          <Pressable style={styles.modalContentRow} onPress={handleTask({ type: 'EDIT', isRoutineTask })}>
             <TaskEdit />
             <Text style={styles.modalContentText}>할 일 수정하기</Text>
           </Pressable>
           {isRoutineTask ? (
-            <Pressable style={styles.modalContentRow} onPress={handleEditTask({ type: 'EDIT', isRoutine: true })}>
+            <Pressable style={styles.modalContentRow} onPress={handleTask({ type: 'EDIT_ROUTINE', isRoutineTask })}>
               <RoutineEdit />
               <Text style={styles.modalContentText}>루틴 수정하기</Text>
             </Pressable>
           ) : null}
-          <Pressable style={styles.modalContentRow} onPress={handleEditTask({ type: 'DELETE' })}>
+          <Pressable style={styles.modalContentRow} onPress={handleTask({ type: 'DELETE', isRoutineTask })}>
             <TaskDelete />
             <Text style={styles.modalContentText}>삭제하기</Text>
           </Pressable>

--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -67,6 +67,9 @@ const Item = ({
 
   const data = id && mode ? todoTaskData ?? dowithTaskData : null;
   const isRoutineTask = !isNil(data?.routineCondition);
+
+  // 현재 시간이 업데이트 하려는 Task가 두윗이고, 등록 시간보다 같거나 이후일 경우
+  const isInvalidUpdateDowithTask = !isTodoMode && dayjs(`${data?.date} ${data?.startTime}`).isSameOrBefore(dayjs());
   const isDisabled = status === TASK_STATUS_ENUM.enum.FAIL;
 
   const { mutate: completeTodoTaskStatusMutate } = useUpdateTodoTaskStatus({ year, month });
@@ -135,9 +138,7 @@ const Item = ({
 
       // 삭제하기 버튼을 눌렀을 때
       if (type === 'DELETE') {
-        // 현재 시간이 삭제하려는 두윗 등록 시간보다 같거나 이후일 경우 삭제 불가 팝업 노출
-        const isInvalidDeleteTask = dayjs(`${data?.date} ${data?.startTime}`).isSameOrBefore(dayjs());
-        if (!isTodoMode && isInvalidDeleteTask) {
+        if (isInvalidUpdateDowithTask) {
           showDialog({
             type: 'ALERT',
             title: '두윗모드 삭제 불가',
@@ -219,8 +220,8 @@ const Item = ({
             {!confirmedImageUrl && !isNil(feedBackCount) && (
               <FeedBackIcon count={feedBackCount as number} status={status} />
             )}
-            <Pressable onPress={handleBottomSheet} disabled={isDisabled}>
-              <EtcDots disabled={isDisabled} />
+            <Pressable onPress={handleBottomSheet} disabled={isInvalidUpdateDowithTask || isDisabled}>
+              <EtcDots disabled={isInvalidUpdateDowithTask || isDisabled} />
             </Pressable>
           </View>
         </View>

--- a/src/components/common/icons/TaskStatusMarking/index.tsx
+++ b/src/components/common/icons/TaskStatusMarking/index.tsx
@@ -78,8 +78,8 @@ const getMarkFillColor = (status: TaskStatus) => {
       return {
         left: 'none',
         right: 'none',
-        backgroundLeft: 'none',
-        backgroundRight: 'none',
+        backgroundLeft: theme.COLORS.PRIMARY.RED_98,
+        backgroundRight: theme.COLORS.SECONDARY.BLUE_95,
       };
   }
 };

--- a/src/constants/queries/index.ts
+++ b/src/constants/queries/index.ts
@@ -15,7 +15,7 @@ const TASK_QUERY_KEY = {
   ADD_TODO: ['task', 'add', 'todo'],
   ADD_DOWITH: ['task', 'add', 'dowith'],
   UPDATE_TODO_STATUS: ['task', 'update', 'todo', 'status'],
-  UPDATE_TODO: ['task', 'update', 'todo'],
+  UPDATE: ['task', 'update'],
   UPDATE_ROUTINE: ['task', 'update', 'routine'],
 } as const;
 

--- a/src/hooks/queries/task/useUpdateTask.ts
+++ b/src/hooks/queries/task/useUpdateTask.ts
@@ -4,30 +4,33 @@ import { useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
 
 import { TASK_QUERY_KEY } from 'constants/queries';
-import { updateTodoTask } from 'services/rest/task';
-import type { RootStackParamList } from 'types/shared';
+import { updateTask } from 'services/rest/task';
+import type { RootStackParamList, TaskModeType } from 'types/shared';
 import type { fetchTaskListResponseSchemeDataType, updateTaskRequestSchemeType } from 'types/task/scheme/api';
 
-const useUpdateTodoTask = ({
+const useUpdateTask = ({
   id,
   type,
+  mode,
   isRoutineTask,
   year,
   month,
 }: {
   id: number;
   type: 'EDIT' | 'DELETE';
+  mode: TaskModeType;
   isRoutineTask: boolean;
   year?: number;
   month?: number;
 }) => {
   const queryClient = useQueryClient();
   const { navigate } = useNavigation<StackNavigationProp<RootStackParamList, 'TASK_FORM'>>();
+  const isTodoMode = mode === 'TODO';
   const isEditType = type === 'EDIT';
 
   return useMutation<string, AxiosError, updateTaskRequestSchemeType | undefined>({
-    mutationKey: TASK_QUERY_KEY.UPDATE_TODO,
-    mutationFn: payload => updateTodoTask({ type, id, isRoutineTask, payload }),
+    mutationKey: [...TASK_QUERY_KEY.UPDATE, isTodoMode ? 'todo' : 'dowith'],
+    mutationFn: payload => updateTask({ type, id, mode: isTodoMode ? 'TODO' : 'DOWITH', isRoutineTask, payload }),
     onMutate: async () => {
       if (type === 'DELETE') {
         await queryClient.cancelQueries({ queryKey: [...TASK_QUERY_KEY.LIST, year, month] });
@@ -54,7 +57,9 @@ const useUpdateTodoTask = ({
       }
     },
     onSuccess: () => {
-      console.log(`투두 ${isEditType ? '업데이트' : '삭제'} 성공! `);
+      console.log(
+        `${isRoutineTask ? '루틴' : '일반'} ${isTodoMode ? '투두' : '두윗'} ${isEditType ? '업데이트' : '삭제'} 성공! `,
+      );
       if (isEditType) {
         navigate('HOME');
       }
@@ -63,4 +68,4 @@ const useUpdateTodoTask = ({
   });
 };
 
-export { useUpdateTodoTask };
+export { useUpdateTask };

--- a/src/hooks/queries/task/useUpdateTodoTask.ts
+++ b/src/hooks/queries/task/useUpdateTodoTask.ts
@@ -11,11 +11,13 @@ import type { fetchTaskListResponseSchemeDataType, updateTaskRequestSchemeType }
 const useUpdateTodoTask = ({
   id,
   type,
+  isRoutineTask,
   year,
   month,
 }: {
   id: number;
   type: 'EDIT' | 'DELETE';
+  isRoutineTask: boolean;
   year?: number;
   month?: number;
 }) => {
@@ -25,7 +27,7 @@ const useUpdateTodoTask = ({
 
   return useMutation<string, AxiosError, updateTaskRequestSchemeType | undefined>({
     mutationKey: TASK_QUERY_KEY.UPDATE_TODO,
-    mutationFn: payload => updateTodoTask({ type, id, payload }),
+    mutationFn: payload => updateTodoTask({ type, id, isRoutineTask, payload }),
     onMutate: async () => {
       if (type === 'DELETE') {
         await queryClient.cancelQueries({ queryKey: [...TASK_QUERY_KEY.LIST, year, month] });

--- a/src/hooks/queries/task/useUpdateTodoTaskStatus.ts
+++ b/src/hooks/queries/task/useUpdateTodoTaskStatus.ts
@@ -3,7 +3,7 @@ import { AxiosError } from 'axios';
 
 import { TASK_QUERY_KEY } from 'constants/queries';
 import { updateStatusTodoTask } from 'services/rest/task';
-import type { updateTodoTaskResponseSchemeType } from 'types/task/scheme/api';
+import type { updateTodoTaskStatusResponseSchemeType } from 'types/task/scheme/api';
 import type { TaskStatusEnumType } from 'types/task/scheme/enum';
 
 interface Props {
@@ -14,7 +14,7 @@ interface Props {
 const useUpdateTodoTaskStatus = ({ year, month }: Props) => {
   const queryClient = useQueryClient();
 
-  return useMutation<updateTodoTaskResponseSchemeType, AxiosError, { id: number; status: TaskStatusEnumType }>({
+  return useMutation<updateTodoTaskStatusResponseSchemeType, AxiosError, { id: number; status: TaskStatusEnumType }>({
     mutationKey: TASK_QUERY_KEY.UPDATE_TODO_STATUS,
     mutationFn: payload => updateStatusTodoTask(payload),
     onSuccess: () => {

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -12,7 +12,6 @@ import LinearGradient from 'react-native-linear-gradient';
 
 import { theme } from 'styles/theme';
 import { TrafficGreenLight } from 'components/common/icons/TrafficGreenLight';
-import { isAos } from 'utils/device';
 import { ArrowRight } from 'components/common/icons/ArrowIcon';
 import { PlusIcon } from 'components/common/icons/PlusIcon';
 import { ListContainerView } from 'components/Task/ListContainerView';

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -96,17 +96,18 @@ const updateStatusTodoTask = async ({
 const updateTodoTask = async ({
   type,
   id,
+  isRoutineTask,
   payload,
 }: {
   type: 'EDIT' | 'DELETE';
   id: number;
+  isRoutineTask: boolean;
   payload?: updateTaskRequestSchemeType;
 }): Promise<string> => {
   try {
     const isEditType = type === 'EDIT';
-    const result = isEditType
-      ? await apiClient.put<string>(`${TASK_API.TODO}/${id}`, payload)
-      : await apiClient.delete<string>(`${TASK_API.TODO}/${id}`);
+    const url = `${TASK_API.TODO}/${id}${isRoutineTask ? '/with-routine' : ''}`;
+    const result = isEditType ? await apiClient.put<string>(url, payload) : await apiClient.delete<string>(url);
     return result.data;
   } catch (e) {
     throw e;

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -93,20 +93,23 @@ const updateStatusTodoTask = async ({
   }
 };
 
-const updateTodoTask = async ({
+const updateTask = async ({
   type,
   id,
+  mode,
   isRoutineTask,
   payload,
 }: {
   type: 'EDIT' | 'DELETE';
   id: number;
+  mode: TaskModeType;
   isRoutineTask: boolean;
   payload?: updateTaskRequestSchemeType;
 }): Promise<string> => {
   try {
+    const isTodoMode = mode === 'TODO';
     const isEditType = type === 'EDIT';
-    const url = `${TASK_API.TODO}/${id}${isRoutineTask ? '/with-routine' : ''}`;
+    const url = `${isTodoMode ? TASK_API.TODO : TASK_API.DOWITH}/${id}${isRoutineTask ? '/with-routine' : ''}`;
     const result = isEditType ? await apiClient.put<string>(url, payload) : await apiClient.delete<string>(url);
     return result.data;
   } catch (e) {
@@ -143,6 +146,6 @@ export {
   fetchDowithTask,
   addDowithTask,
   updateStatusTodoTask,
-  updateTodoTask,
+  updateTask,
   updateTaskRoutine,
 };

--- a/src/types/shared/index.ts
+++ b/src/types/shared/index.ts
@@ -15,6 +15,7 @@ type RootStackParamList = {
   TASK_FORM: {
     screen: 'COMMON' | 'ROUTINE';
     date: string;
+    isRoutineTask: boolean;
     id?: number;
     mode?: TaskModeType;
   };
@@ -39,10 +40,12 @@ type TaskModeType = 'TODO' | 'DOWITH';
 type TaskFormStackParamList = {
   COMMON: {
     id: number;
+    isRoutineTask: boolean;
     mode?: TaskModeType;
   };
   ROUTINE: {
     id: number;
+    isRoutineTask: boolean;
     mode: TaskModeType;
   };
 };

--- a/src/types/shared/index.ts
+++ b/src/types/shared/index.ts
@@ -15,7 +15,7 @@ type RootStackParamList = {
   TASK_FORM: {
     screen: 'COMMON' | 'ROUTINE';
     date: string;
-    isRoutineTask: boolean;
+    isRoutineTask?: boolean;
     id?: number;
     mode?: TaskModeType;
   };


### PR DESCRIPTION
## 🤔 개요
<!-- 해당 작업을 하게 된 배경에 대해 적어주세요 -->
Task 수정(루틴 포함) API 및 루틴 수정/삭제 API(루틴 포함) 연동 및 기타 정책, 버그 수정 작업을 해야 함

## 📝 작업 내용
<!-- 작업한 내용을 정리하여 적어주세요 -->
1. Task 수정(루틴 포함) API 연동
2. Task 루틴 수정/삭제 API 연동
3. 루틴 등록/수정 시 캘린더 접었다 다시 폈을 때 상태 초기화되는 버그 수정
4. 정책에 맞게 유효성 검사 관련 로직 수정(task 이름 길이, date picker minimum date)
5. 현재 시간이 두윗 시작 시간보다 이후일 경우 Task 설정 버튼 비활성화
6. Task 등록 시, 현재 시간이 두윗 시작 시간보다 이후일 경우 두윗 Task 선택 불가 처리 및 팝업 노출
7. 캘린더 Task 이행 상태 아이콘 svg 설정 값 수정

<!-- (선택)작업한 내용에 대해 달라진 화면을 스크린샷이나 동영상으로 첨부하여 보여주세요 
## 📸 작업 화면
<table>
<tr>
<td></td>
<td>AS-IS</td>
<td>TO-BE</td>
</tr>
<tr>
<td>🤖 AOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요 
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
<tr>
<td>🍎 IOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
</table>
-->

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->

