### PR TITLE
[TAS-550]add: Foreground 알림 노출 로직 구현 및 기타 작업

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   root: true,
   extends: '@react-native',
+  rules: {
+    'react-hooks/exhaustive-deps': 'warn',
+  },
 };

--- a/App.tsx
+++ b/App.tsx
@@ -164,10 +164,6 @@ function AppContent() {
     // 회원가입이 완료되었을 경우 알림 레이어 초기화
     if (!isNeedSignUp) {
       initNotificationLayer({
-        // 포그라운드 메시지 처리 (원하면 notifee 로컬 알림 등)
-        onForegroundMessage: async message => {
-          console.log('[FCM][FG] 메세지 수신: ', message);
-        },
         // 토큰 변경 시 서버 동기화
         onTokenChanged: async newToken => {
           console.log('onTokenChanged: ', newToken);

--- a/App.tsx
+++ b/App.tsx
@@ -86,7 +86,7 @@ function AppContent() {
     isLoggedIn,
     isNeedSignUp,
     isHydrated,
-    authActions: { setTokenInfo, setIsLoggedIn, setIsNeedRefreshToken, setIsNeedSignUp, initAuthInfo },
+    authActions: { setIsNeedRefreshToken },
   } = useStore(
     ({
       tokenInfo,
@@ -94,14 +94,14 @@ function AppContent() {
       isLoggedIn,
       isNeedSignUp,
       isHydrated,
-      authActions: { setTokenInfo, setIsLoggedIn, setIsNeedRefreshToken, setIsNeedSignUp, initAuthInfo },
+      authActions: { setIsNeedRefreshToken },
     }) => ({
       tokenInfo,
       isNeedRefreshToken,
       isLoggedIn,
       isNeedSignUp,
       isHydrated,
-      authActions: { setTokenInfo, setIsLoggedIn, setIsNeedRefreshToken, setIsNeedSignUp, initAuthInfo },
+      authActions: { setIsNeedRefreshToken },
     }),
   );
 
@@ -139,9 +139,7 @@ function AppContent() {
   });
 
   /**
-   * 초기 앱 진입 시 실행되는 로직
-   * - 토큰 재발급
-   * - FCM 알림 레이어 초기화
+   * 토큰 재발급 로직
    */
   useEffect(() => {
     if (!isHydrated) {
@@ -160,13 +158,26 @@ function AppContent() {
         },
       );
     }
+  }, [isHydrated, isNeedRefreshToken, tokenInfo.refresh?.token]);
+
+  /**
+   * 알림 레이어 초기화 (단 한 번만 실행)
+   */
+  useEffect(() => {
+    if (!isHydrated) {
+      return;
+    }
 
     // 회원가입이 완료되었을 경우 알림 레이어 초기화
     if (!isNeedSignUp) {
+      console.log('🚀 알림 레이어 초기화 시작');
+
       initNotificationLayer({
         // 토큰 변경 시 서버 동기화
         onTokenChanged: async newToken => {
           console.log('onTokenChanged: ', newToken);
+          const { isLoggedIn, isNeedSignUp } = useStore.getState();
+
           // 로그인 완료 & 회원가입 완료 상태에서만 토큰 갱신 요청
           if (!isLoggedIn || isNeedSignUp) {
             return;
@@ -182,18 +193,7 @@ function AppContent() {
         subscribeAppState,
       });
     }
-  }, [
-    tokenInfo,
-    isNeedRefreshToken,
-    isHydrated,
-    isLoggedIn,
-    isNeedSignUp,
-    setIsLoggedIn,
-    setIsNeedRefreshToken,
-    setIsNeedSignUp,
-    setTokenInfo,
-    subscribeAppState,
-  ]);
+  }, [isHydrated, isNeedSignUp]);
 
   // useEffect(() => {
   //   initAuthInfo();

--- a/index.js
+++ b/index.js
@@ -18,14 +18,13 @@ import { AppRegistry } from 'react-native';
 import App from './App';
 import { name as appName } from './app.json';
 import messaging from '@react-native-firebase/messaging';
+import { handleBackgroundMessage } from 'utils/notification';
 
 // 백그라운드 메세지 핸들러 재등록 방지
 if (!__DEV__ || !global.__hasSetBGMessageHandler) {
   // 앱이 종료/백그라운드 상태일 때 메시지 핸들러 등록
-  messaging().setBackgroundMessageHandler(async remoteMessage => {
-    console.log('[FCM][Background] message:', remoteMessage);
-    // notifee 알림 처리
-  });
+  messaging().setBackgroundMessageHandler(handleBackgroundMessage);
+
   if (__DEV__) {
     global.__hasSetBGMessageHandler = true;
   }

--- a/src/components/Signup/ServiceAgree/index.tsx
+++ b/src/components/Signup/ServiceAgree/index.tsx
@@ -3,11 +3,13 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { Controller, SubmitHandler, useFormContext } from 'react-hook-form';
 import { Checkbox, Divider, IconButton } from 'react-native-paper';
 import { getBottomSpace } from 'react-native-iphone-screen-helper';
+import dayjs from 'dayjs';
 
 import type { signUpRequestSchemeType } from 'types/member/scheme/api';
 import { theme } from 'styles/theme';
 import { useSignUp } from 'hooks/queries/member/useSignUp';
 import { isAos } from 'utils/device';
+import { useDialog } from 'components/common/Dialog/Provider';
 
 type AgreementKeys = keyof signUpRequestSchemeType['agreements'];
 type AgreementLabels = `agreements.${AgreementKeys}`;
@@ -19,9 +21,11 @@ const CHECKBOX_MAP_LIST: { label: AgreementLabels; text: string; isLinkable: boo
 ];
 
 const ServiceAgree = () => {
+  const { handleSubmit, control, watch, setValue } = useFormContext<signUpRequestSchemeType>();
+  const { showDialog, hideDialog } = useDialog();
+
   const [allChecked, setAllChecked] = useState<boolean>(false);
   const [ageOfAgree, setAgeOfAgree] = useState<boolean>(false);
-  const { handleSubmit, control, watch, setValue } = useFormContext<signUpRequestSchemeType>();
   const termsOfAgree = watch('agreements.termsOfAgree');
   const privacy = watch('agreements.privacy');
   const advertisement = watch('agreements.advertisement');
@@ -36,17 +40,51 @@ const ServiceAgree = () => {
     return true;
   }, [ageOfAgree, allChecked, privacy, termsOfAgree]);
 
-  const onSubmit: SubmitHandler<signUpRequestSchemeType> = useCallback(
-    values => {
-      console.log(values);
-      const { dateOfBirth } = values;
-      mutate({
-        ...values,
-        dateOfBirth: dateOfBirth.replaceAll(' / ', '-'),
+  const onSubmit: SubmitHandler<signUpRequestSchemeType> = useCallback(values => {
+    console.log(values);
+    const {
+      nickname,
+      dateOfBirth,
+      agreements: { advertisement },
+    } = values;
+
+    // 광고성 알림 동의 안했을 경우 동의 강조 관련 Dialog 노출
+    if (!advertisement) {
+      showDialog({
+        title: '광고성 정보 수신 동의',
+        content: '광고성 정보 수신 미동의시 다양한 혜택 및\n이벤트 참여에 제한이 있을 수 있습니다.',
+        leftButtonText: '미동의',
+        rightButtonText: '동의',
+        handleLeftButton: () => hideDialog,
+        handleRightButton: () => {
+          setValue('agreements.advertisement', true);
+          hideDialog();
+        },
       });
-    },
-    [mutate],
-  );
+
+      showDialog({
+        type: 'ALERT',
+        title: '광고성 정보 수신거부 처리',
+        content: '광고성 수신 정보 동의는 설정 >\n마케팅ㆍ혜택 알림에서 변경 가능합니다.',
+        subContent: `작성자 : ${nickname}\n일시 : ${dayjs().format('YYYY년 MM월 DD일')}\n상태 : 광고성 정보 수신 ${
+          advertisement ? '동의' : '미동의'
+        }`,
+        handleAlertButton: () => {
+          mutate({
+            ...values,
+            dateOfBirth: dateOfBirth.replaceAll(' / ', '-'),
+          });
+          hideDialog();
+        },
+      });
+      return;
+    }
+
+    mutate({
+      ...values,
+      dateOfBirth: dateOfBirth.replaceAll(' / ', '-'),
+    });
+  }, []);
 
   const onPressCheckBox = useCallback(
     (label: AgreementLabels) => () => {

--- a/src/components/Signup/ServiceAgree/index.tsx
+++ b/src/components/Signup/ServiceAgree/index.tsx
@@ -10,6 +10,7 @@ import { theme } from 'styles/theme';
 import { useSignUp } from 'hooks/queries/member/useSignUp';
 import { isAos } from 'utils/device';
 import { useDialog } from 'components/common/Dialog/Provider';
+import { useStore } from 'stores/index';
 
 type AgreementKeys = keyof signUpRequestSchemeType['agreements'];
 type AgreementLabels = `agreements.${AgreementKeys}`;
@@ -22,6 +23,9 @@ const CHECKBOX_MAP_LIST: { label: AgreementLabels; text: string; isLinkable: boo
 
 const ServiceAgree = () => {
   const { handleSubmit, control, watch, setValue } = useFormContext<signUpRequestSchemeType>();
+  const {
+    notificationActions: { updateNotificationSettings },
+  } = useStore();
   const { showDialog, hideDialog } = useDialog();
 
   const [allChecked, setAllChecked] = useState<boolean>(false);
@@ -77,9 +81,16 @@ const ServiceAgree = () => {
           hideDialog();
         },
       });
+
+      updateNotificationSettings({
+        marketing: advertisement,
+      });
       return;
     }
 
+    updateNotificationSettings({
+      marketing: true,
+    });
     mutate({
       ...values,
       dateOfBirth: dateOfBirth.replaceAll(' / ', '-'),

--- a/src/components/Task/Form/Common/index.tsx
+++ b/src/components/Task/Form/Common/index.tsx
@@ -1,7 +1,6 @@
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import React, { useCallback, useRef, useState } from 'react';
 import { Controller, SubmitHandler, useFormContext } from 'react-hook-form';
-import DatePicker from 'react-native-date-picker';
 import { getBottomSpace } from 'react-native-iphone-screen-helper';
 import type { BottomSheetModalMethods } from '@gorhom/bottom-sheet/src/types';
 import dayjs from 'dayjs';
@@ -22,6 +21,7 @@ import { StackScreenProps } from '@react-navigation/stack';
 import { useUpdateTask } from 'hooks/queries/task/useUpdateTask';
 import { useDialog } from 'components/common/Dialog/Provider';
 import { ArrowRight } from 'components/common/icons/ArrowIcon';
+import { DateTimePicker } from 'components/common/DateTimePicker';
 
 const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'COMMON'>) => {
   const { params } = route;
@@ -37,8 +37,8 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
   } = useFormContext<addTaskRequestSchemeType>();
   const categoryBottomSheetMethodsRef = useRef<BottomSheetModalMethods>(null);
   const routineBottomSheetMethodsRef = useRef<BottomSheetModalMethods>(null);
+  const dateTimePickerRef = useRef<BottomSheetModalMethods>(null);
 
-  const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
   const [taskMode, setTaskMode] = useState<TaskModeType | null>(params.mode ?? null);
   const isTodoMode = taskMode === 'TODO';
 
@@ -189,16 +189,13 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
     );
   };
 
-  const toggleDatePicker = useCallback(
-    (isOpen: boolean) => () => {
-      if (isFormDisabled) {
-        return;
-      }
+  const handleDatePicker = useCallback(() => {
+    if (isFormDisabled) {
+      return;
+    }
 
-      setDatePickerOpen(isOpen);
-    },
-    [isFormDisabled],
-  );
+    dateTimePickerRef.current?.present();
+  }, [isFormDisabled]);
 
   const handlePresentModalPress = useCallback(() => {
     if (isFormDisabled) {
@@ -214,7 +211,7 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
         shouldDirty: true,
         shouldTouch: true,
       });
-      setDatePickerOpen(false);
+      dateTimePickerRef.current?.dismiss();
     },
     [setValue],
   );
@@ -331,7 +328,7 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
             </View>
             <Pressable
               style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 16 }}
-              onPress={toggleDatePicker(true)}
+              onPress={handleDatePicker}
             >
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
                 <Text
@@ -419,16 +416,14 @@ const Form = ({ route, navigation }: StackScreenProps<TaskFormStackParamList, 'C
           </Text>
         </Pressable>
       </View>
-      <DatePicker
-        modal
-        open={datePickerOpen}
+      <DateTimePicker
+        ref={dateTimePickerRef}
         mode="time"
-        minimumDate={!isTodoMode ? new Date() : undefined}
+        title="시작 시간"
+        description="이미 지난 시간은 선택할 수 없어요."
+        minimumDate={!isTodoMode ? dayjs().toDate() : undefined}
         minuteInterval={5}
-        locale="ko-KR"
-        date={startTime ? dayjs(startTime, 'HH:mm:ss').toDate() : dayjs().toDate()}
         onConfirm={handleDateChange}
-        onCancel={toggleDatePicker(false)}
       />
       <CategoryBottomSheet
         ref={categoryBottomSheetMethodsRef}

--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -1,11 +1,10 @@
 import React, { useRef, useState } from 'react';
-import { Alert, Dimensions, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Alert, Dimensions, Image, Linking, Pressable, StyleSheet, Text, View } from 'react-native';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import dayjs from 'dayjs';
 import { launchCamera, launchImageLibrary } from 'react-native-image-picker';
-import notifee from '@notifee/react-native';
 
 import { TaskSuccess } from 'components/common/icons/TaskSuccess';
 import { EtcDots } from 'components/common/icons/EtcDots';
@@ -177,7 +176,7 @@ const Item = ({
               hideDialog();
             },
             handleRightButton: () => {
-              notifee.openNotificationSettings();
+              Linking.openSettings();
               hideDialog();
             },
           });

--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import dayjs from 'dayjs';
 import { launchCamera, launchImageLibrary } from 'react-native-image-picker';
+import notifee from '@notifee/react-native';
 
 import { TaskSuccess } from 'components/common/icons/TaskSuccess';
 import { EtcDots } from 'components/common/icons/EtcDots';
@@ -151,13 +152,36 @@ const Item = ({
 
       // 사용자가 취소한 경우
       if (result.didCancel) {
-        console.log(`사용자가 ${type === 'CAMERA' ? '카메라를' : '갤러리를'} 취소했습니다`);
+        console.log(`사용자가 ${type === 'CAMERA' ? '카메라' : '갤러리'} 접근 권한을 취소했습니다`);
         return;
       }
 
       // 권한 거부 또는 에러 처리
       if (result.errorCode) {
         console.error(`[${type === 'CAMERA' ? '카메라' : '갤러리'} 에러]:`, result.errorCode, result.errorMessage);
+        // 권한 거부 에러인 경우만 다이얼로그 표시
+        const isPermissionDenied =
+          result.errorCode === 'permission' ||
+          result.errorCode === 'camera_unavailable' ||
+          result.errorCode === 'others';
+
+        if (isPermissionDenied) {
+          showDialog({
+            title: `${type === 'CAMERA' ? '카메라' : '갤러리'} 접근 권한 필요`,
+            content: `${
+              type === 'CAMERA' ? '카메라 ' : '갤러리'
+            } 접근 권한을 허용해야 해요!\n기기 설정에서 권한을 변경할 수 있어요`,
+            leftButtonText: '취소',
+            rightButtonText: '설정 바로가기',
+            handleLeftButton: () => {
+              hideDialog();
+            },
+            handleRightButton: () => {
+              notifee.openNotificationSettings();
+              hideDialog();
+            },
+          });
+        }
 
         // iOS 시뮬레이터에서 카메라 사용 시 에러 처리
         if (type === 'CAMERA' && !isAos && result.errorCode === 'camera_unavailable') {

--- a/src/components/Task/Item/index.tsx
+++ b/src/components/Task/Item/index.tsx
@@ -172,9 +172,7 @@ const Item = ({
             } 접근 권한을 허용해야 해요!\n기기 설정에서 권한을 변경할 수 있어요`,
             leftButtonText: '취소',
             rightButtonText: '설정 바로가기',
-            handleLeftButton: () => {
-              hideDialog();
-            },
+            handleLeftButton: () => hideDialog,
             handleRightButton: () => {
               Linking.openSettings();
               hideDialog();

--- a/src/components/common/DateTimePicker/index.tsx
+++ b/src/components/common/DateTimePicker/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import dayjs from 'dayjs';
 import DatePicker, { DatePickerProps } from 'react-native-date-picker';
@@ -16,12 +16,60 @@ interface Props extends Pick<DatePickerProps, 'minimumDate' | 'maximumDate' | 'm
 const DateTimePicker = forwardRef<BottomSheetModalMethods, Props>((props, ref) => {
   const { title, description, mode, onConfirm, minimumDate, maximumDate, minuteInterval } = props;
   const innerRef = useRef<BottomSheetModalMethods>(null);
-  const [selectedDate, setSelectedDate] = useState<Date>(dayjs().subtract(14, 'year').toDate());
+
+  // time 모드일 경우, minimumDate가 있으면 가장 가까운 미래 시간으로 설정
+  const getInitialDate = () => {
+    if (mode === 'time' && minimumDate && minuteInterval) {
+      const now = dayjs();
+      const currentMinutes = now.minute();
+
+      // minuteInterval에 맞춰 올림
+      const nextMinutes = Math.ceil(currentMinutes / minuteInterval) * minuteInterval;
+
+      // 60분을 넘으면 다음 시간으로
+      if (nextMinutes >= 60) {
+        return now.add(1, 'hour').minute(0).second(0).millisecond(0).toDate();
+      }
+
+      return now.minute(nextMinutes).second(0).millisecond(0).toDate();
+    }
+
+    return dayjs().toDate();
+  };
+
+  const [selectedDate, setSelectedDate] = useState<Date>(getInitialDate());
+  const [isDisabled, setIsDisabled] = useState(false);
 
   const handleSubmit = () => {
     onConfirm(selectedDate);
     innerRef.current?.dismiss();
   };
+
+  useEffect(() => {
+    let disabled = false;
+    const selected = dayjs(selectedDate);
+
+    // 최소 Date를 설정했을 경우
+    if (minimumDate) {
+      const minimum = dayjs(minimumDate);
+
+      // 선택한 시간이 최소 시간보다 이전이면 비활성화
+      if (selected.isBefore(minimum)) {
+        disabled = true;
+      }
+    }
+
+    // 최대 Date를 설정했을 경우
+    if (maximumDate) {
+      const maximum = dayjs(maximumDate);
+      // 선택한 시간이 최대 시간보다 이후면 비활성화
+      if (selected.isAfter(maximum)) {
+        disabled = true;
+      }
+    }
+
+    setIsDisabled(disabled);
+  }, [selectedDate, minimumDate, maximumDate, mode]);
 
   useImperativeHandle(ref, () => innerRef.current!);
 
@@ -30,7 +78,7 @@ const DateTimePicker = forwardRef<BottomSheetModalMethods, Props>((props, ref) =
       ref={innerRef}
       title={title}
       description={description}
-      buttonConfig={{ title: '저장하기', isDisabled: false }}
+      buttonConfig={{ title: '저장하기', isDisabled }}
       snapPoints={['46%']}
       handleButtonSubmit={handleSubmit}
     >

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -1,14 +1,85 @@
 import type { AppStateStatus } from 'react-native';
 import messaging, { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 import notifee, { AndroidImportance, AuthorizationStatus } from '@notifee/react-native';
+import { AndroidVisibility } from '@notifee/react-native/src/types/NotificationAndroid';
 
 import { isAos } from 'utils/device';
 import { useStore } from 'stores/index';
 
 let initialized = false;
+let channelCreated = false;
 let unsubOnMessage: (() => void) | null = null;
 let unsubOnTokenRefresh: (() => void) | null = null;
 let unsubAppState: (() => void) | null = null;
+
+const CHANNEL_ID = 'default';
+
+/**
+ * 알림 채널 생성
+ */
+const createNotificationChannel = async () => {
+  if (!isAos || channelCreated) {
+    return CHANNEL_ID;
+  }
+
+  const channelId = await notifee.createChannel({
+    id: CHANNEL_ID,
+    name: 'Default Channel',
+    importance: AndroidImportance.HIGH,
+    vibration: true,
+  });
+
+  channelCreated = true;
+  return channelId;
+};
+
+/**
+ * Foreground/Background에서 수신한 FCM 메시지를 notifee를 사용하여 로컬 알림으로 표시
+ */
+const displayNotification = async (message: FirebaseMessagingTypes.RemoteMessage) => {
+  try {
+    const imageUrl = message.notification?.image || (message.data?.imageUrl as string | undefined);
+
+    await notifee.displayNotification({
+      title: message.notification?.title || '새 알림',
+      body: message.notification?.body || '',
+      android: {
+        channelId: CHANNEL_ID,
+        smallIcon: 'ic_launcher',
+        ...(imageUrl && {
+          largeIcon: imageUrl,
+        }),
+        importance: AndroidImportance.HIGH,
+        vibrationPattern: [300, 500],
+        visibility: AndroidVisibility.PUBLIC,
+        pressAction: {
+          id: 'default',
+        },
+        timestamp: Date.now(),
+        showTimestamp: true,
+      },
+      ...(imageUrl && {
+        ios: {
+          attachments: [{ url: imageUrl }],
+        },
+      }),
+      data: message.data,
+    });
+  } catch (error) {
+    console.error('Foreground 알림 표시 실패:', error);
+  }
+};
+
+/**
+ * Background 메시지 핸들러
+ */
+const handleBackgroundMessage = async (remoteMessage: FirebaseMessagingTypes.RemoteMessage) => {
+  console.log('[FCM][BG] 백그라운드 메시지 수신:', remoteMessage);
+
+  // Background에서도 채널이 필요하므로 생성
+  await createNotificationChannel();
+  await displayNotification(remoteMessage);
+};
 
 /**
  * 초기화 진입점: FCM/Notifee 권한을 확인 및 요청하고,
@@ -68,14 +139,8 @@ const initNotificationLayer = async (options?: {
     await messaging().registerDeviceForRemoteMessages();
   }
 
-  // Android: 채널 보장
-  if (isAos) {
-    await notifee.createChannel({
-      id: 'default',
-      name: 'Default',
-      importance: AndroidImportance.DEFAULT,
-    });
-  }
+  // AOS: 채널 생성
+  await createNotificationChannel();
 
   // 최초 토큰 확보 & 서버 동기화(변경시에만 처리하도록 onTokenChanged 내부에서 분기)
   try {
@@ -87,7 +152,9 @@ const initNotificationLayer = async (options?: {
 
   // 포그라운드 수신(1회 등록)
   unsubOnMessage = messaging().onMessage(async message => {
+    console.log('[FCM][FG] 메시지 수신:', message);
     await onMessage(message);
+    await displayNotification(message);
   });
 
   // 토큰 갱신(1회 등록)
@@ -168,4 +235,4 @@ const disposeNotificationLayer = () => {
   initialized = false;
 };
 
-export { initNotificationLayer, ensurePermissionWatcher, disposeNotificationLayer };
+export { initNotificationLayer, ensurePermissionWatcher, disposeNotificationLayer, handleBackgroundMessage };

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -5,6 +5,7 @@ import { AndroidVisibility } from '@notifee/react-native/src/types/NotificationA
 
 import { isAos } from 'utils/device';
 import { useStore } from 'stores/index';
+import { updateNotificationSettings as mutateNotificationSettings } from 'services/rest/member';
 
 let initialized = false;
 let channelCreated = false;
@@ -13,6 +14,44 @@ let unsubOnTokenRefresh: (() => void) | null = null;
 let unsubAppState: (() => void) | null = null;
 
 const CHANNEL_ID = 'default';
+
+/**
+ * 알림 설정을 서버와 FE 상태에 동기화하는 함수
+ */
+const syncNotificationSettings = async (authorized: boolean) => {
+  const {
+    notificationSettings,
+    notificationActions: { updateNotificationSettings },
+  } = useStore.getState();
+
+  const settings = authorized
+    ? {
+        baseAlarmYn: true,
+        todoBotYn: true,
+        feedbackYn: true,
+        marketingYn: notificationSettings.marketing,
+      }
+    : {
+        baseAlarmYn: false,
+        todoBotYn: false,
+        feedbackYn: false,
+        marketingYn: false,
+      };
+
+  try {
+    await mutateNotificationSettings(settings);
+    updateNotificationSettings({
+      base: settings.baseAlarmYn,
+      todoBot: settings.todoBotYn,
+      feedback: settings.feedbackYn,
+      marketing: settings.marketingYn,
+    });
+
+    console.log('✅[syncNotificationSettings] 알림 설정 동기화 완료:', settings);
+  } catch (error) {
+    console.error('❌[syncNotificationSettings] 알림 설정 동기화 실패:', error);
+  }
+};
 
 /**
  * 알림 채널 생성 (한 번만 실행)
@@ -138,6 +177,7 @@ const initNotificationLayer = async (options?: {
 
   if (!authorized) {
     console.log('❌ [initNotificationLayer] 권한 거부됨');
+    await syncNotificationSettings(false);
 
     // watcher 등록 전에 체크 (이미 구독 중이면 중복 등록 방지)
     if (!unsubAppState) {
@@ -151,6 +191,7 @@ const initNotificationLayer = async (options?: {
   }
 
   console.log('✅ [initNotificationLayer] 권한 확인 완료');
+  await syncNotificationSettings(true);
 
   // iOS: 원격 알림 등록
   if (!isAos) {
@@ -236,6 +277,7 @@ const ensurePermissionWatcher = (options?: Parameters<typeof initNotificationLay
 
     if (authorized) {
       console.log('✅ [ensurePermissionWatcher] 권한 허용됨, 초기화 재시도');
+      await syncNotificationSettings(true);
       await initNotificationLayer(options);
     } else {
       console.log('❌ [ensurePermissionWatcher] 여전히 권한 거부됨');

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -1,4 +1,4 @@
-import type { AppStateStatus } from 'react-native';
+import { AppStateStatus } from 'react-native';
 import messaging, { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 import notifee, { AndroidImportance, AuthorizationStatus } from '@notifee/react-native';
 import { AndroidVisibility } from '@notifee/react-native/src/types/NotificationAndroid';
@@ -15,7 +15,7 @@ let unsubAppState: (() => void) | null = null;
 const CHANNEL_ID = 'default';
 
 /**
- * 알림 채널 생성
+ * 알림 채널 생성 (한 번만 실행)
  */
 const createNotificationChannel = async () => {
   if (!isAos || channelCreated) {
@@ -30,6 +30,7 @@ const createNotificationChannel = async () => {
   });
 
   channelCreated = true;
+  console.log('✅ 채널 생성 완료:', channelId);
   return channelId;
 };
 
@@ -66,7 +67,7 @@ const displayNotification = async (message: FirebaseMessagingTypes.RemoteMessage
       data: message.data,
     });
   } catch (error) {
-    console.error('Foreground 알림 표시 실패:', error);
+    console.error('❌ 알림 표시 실패:', error);
   }
 };
 
@@ -101,13 +102,11 @@ const initNotificationLayer = async (options?: {
   onTokenChanged?: (token: string) => Promise<void> | void;
   subscribeAppState?: (callback: (state: AppStateStatus) => void) => () => void;
 }) => {
-  const {
-    isNeedSignUp,
-    authActions: { setIsNeedSignUp },
-  } = useStore.getState();
+  console.log('🚀 [initNotificationLayer] 시작');
 
   // 이미 초기화되어 있으면 스킵
   if (initialized) {
+    console.log('⚠️ [initNotificationLayer] 이미 초기화됨, 스킵');
     return;
   }
 
@@ -115,58 +114,84 @@ const initNotificationLayer = async (options?: {
   const onTokenChanged = options?.onTokenChanged ?? (async () => {});
 
   // 현재 권한 확인
+  console.log('🔐 [initNotificationLayer] 권한 확인 중...');
   const currentSetting = await notifee.getNotificationSettings();
   let authorized = currentSetting.authorizationStatus >= AuthorizationStatus.AUTHORIZED;
+  console.log('[initNotificationLayer] 현재 권한 상태:', currentSetting.authorizationStatus, '허용됨:', authorized);
 
-  // 권한 요청이 허용되지 않은 상태일 때 권한 요청
-  if (!authorized) {
-    const res = await notifee.requestPermission();
-    authorized = res.authorizationStatus >= AuthorizationStatus.AUTHORIZED;
-    if (!authorized) {
-      // 회원가입 진행중일 경우 값 OFF
-      if (isNeedSignUp) {
-        setIsNeedSignUp(false);
-      }
-      // 권한 요청을 거부하면 초기화 미수행 하고 포그라운드 복귀 감시로 재시도 함. initialized 값 수정 x
-      ensurePermissionWatcher(options); // 설정에서 바꾸고 돌아오면 재시도
-      return;
+  // 이미 알림 설정이 거부된 경우
+  if (currentSetting.authorizationStatus === AuthorizationStatus.DENIED) {
+    console.log('❌ [initNotificationLayer] 권한이 이미 거부됨');
+
+    // 권한 watcher 등록
+    if (!unsubAppState) {
+      console.log('👀 [initNotificationLayer] 권한 watcher 등록');
+      ensurePermissionWatcher(options);
     }
+    return;
   }
 
-  // 권한이 허용이라면 초기화 수행
+  console.log('🙏 [initNotificationLayer] 권한 요청 중...');
+  const res = await notifee.requestPermission();
+  authorized = res.authorizationStatus >= AuthorizationStatus.AUTHORIZED;
+  console.log('[initNotificationLayer] 권한 요청 결과:', res.authorizationStatus, '허용됨:', authorized);
+
+  if (!authorized) {
+    console.log('❌ [initNotificationLayer] 권한 거부됨');
+
+    // watcher 등록 전에 체크 (이미 구독 중이면 중복 등록 방지)
+    if (!unsubAppState) {
+      console.log('👀 [initNotificationLayer] 권한 watcher 등록');
+      ensurePermissionWatcher(options);
+    } else {
+      console.log('⚠️ [initNotificationLayer] 권한 watcher 이미 등록됨, SKIP');
+    }
+
+    return;
+  }
+
+  console.log('✅ [initNotificationLayer] 권한 확인 완료');
+
   // iOS: 원격 알림 등록
   if (!isAos) {
+    console.log('📱 [initNotificationLayer] iOS 원격 알림 등록 중...');
     await messaging().registerDeviceForRemoteMessages();
   }
 
   // AOS: 채널 생성
   await createNotificationChannel();
 
-  // 최초 토큰 확보 & 서버 동기화(변경시에만 처리하도록 onTokenChanged 내부에서 분기)
+  // FCM 토큰 확보 & 서버 동기화(변경시에만 처리하도록 onTokenChanged 내부에서 분기)
   try {
+    console.log('🔑 [initNotificationLayer] FCM 토큰 확보 중...');
     const token = await messaging().getToken();
+    console.log('✅ [initNotificationLayer] FCM 토큰 확보 완료');
     await onTokenChanged(token);
   } catch (e) {
-    console.log('FCM 토큰을 가져오는 데 실패했습니다.');
+    console.error('❌ [initNotificationLayer] FCM 토큰 확보 실패:', e);
   }
 
-  // 포그라운드 수신(1회 등록)
+  // 포그라운드 메시지 리스너
+  console.log('👂 [initNotificationLayer] Foreground 리스너 등록 중...');
   unsubOnMessage = messaging().onMessage(async message => {
     console.log('[FCM][FG] 메시지 수신:', message);
     await onMessage(message);
     await displayNotification(message);
   });
 
-  // 토큰 갱신(1회 등록)
+  // 토큰 갱신 리스너
+  console.log('🔄 [initNotificationLayer] 토큰 갱신 리스너 등록 중...');
   unsubOnTokenRefresh = messaging().onTokenRefresh(async newToken => {
+    console.log('[FCM] 토큰 갱신:', newToken);
     await onTokenChanged(newToken);
   });
 
-  setIsNeedSignUp(false);
   initialized = true;
+  console.log('🎉 [initNotificationLayer] 초기화 완료!');
 
   // 권한 감시 리스너는 더 이상 불필요하면 제거
   if (unsubAppState) {
+    console.log('🗑️ [initNotificationLayer] 권한 watcher 제거');
     unsubAppState();
     unsubAppState = null;
   }
@@ -176,38 +201,44 @@ const initNotificationLayer = async (options?: {
  * 권한이 거부된 상태에서 앱이 Foreground로 복귀했을 때,
  * 다시 권한 상태를 체크하여 허용으로 변경되면 initNotificationLayer를 재호출한다.
  *
- * - initialized 상태가 true라면 이미 초기화된 것이므로 무시한다.
- * - 중복 등록을 막기 위해 unsubAppState가 존재하면 재등록하지 않는다.
  * - AppStateProvider의 subscribe 함수를 통해 AppState를 구독한다.
  *
  * @param options initNotificationLayer와 동일한 콜백 옵션
  */
 const ensurePermissionWatcher = (options?: Parameters<typeof initNotificationLayer>[0]) => {
-  // 이미 구독 중이면 중복 등록 방지
-  if (unsubAppState) {
-    return;
-  }
+  console.log('👀 [ensurePermissionWatcher] 호출됨');
 
   const subscribeAppState = options?.subscribeAppState;
 
   // subscribeAppState가 없으면 경고 (AppStateProvider 밖에서 호출된 경우)
   if (!subscribeAppState) {
-    console.warn('ensurePermissionWatcher: subscribeAppState가 제공되지 않았습니다.');
+    console.warn('⚠️ [ensurePermissionWatcher] subscribeAppState가 제공되지 않았습니다.');
     return;
   }
 
+  console.log('✅ [ensurePermissionWatcher] AppState 구독 등록');
+
   // AppStateProvider의 subscribe 함수를 사용하여 AppState 구독
   unsubAppState = subscribeAppState(async state => {
-    // active 상태가 아니거나 이미 초기화되었으면 스킵
-    if (state !== 'active' || initialized) {
+    console.log('📱 [ensurePermissionWatcher] AppState 변경:', state);
+
+    // active 상태가 아니면 스킵
+    if (state !== 'active') {
+      console.log('⚠️ [ensurePermissionWatcher] active 아님, 스킵');
       return;
     }
+
     // 권한 상태 재확인
+    console.log('🔐 [ensurePermissionWatcher] 권한 재확인 중...');
     const settings = await notifee.getNotificationSettings();
     const authorized = settings.authorizationStatus >= AuthorizationStatus.AUTHORIZED;
+    console.log('권한 상태:', settings.authorizationStatus, '허용됨:', authorized);
+
     if (authorized) {
-      // 권한 허용으로 바뀌었으면 초기화 재시도
+      console.log('✅ [ensurePermissionWatcher] 권한 허용됨, 초기화 재시도');
       await initNotificationLayer(options);
+    } else {
+      console.log('❌ [ensurePermissionWatcher] 여전히 권한 거부됨');
     }
   });
 };
@@ -222,6 +253,8 @@ const ensurePermissionWatcher = (options?: Parameters<typeof initNotificationLay
  * 주로 로그아웃 시점, 또는 알림 기능을 완전히 종료해야 할 때 호출한다.
  */
 const disposeNotificationLayer = () => {
+  console.log('🗑️ [disposeNotificationLayer] 시작');
+
   unsubOnMessage?.();
   unsubOnMessage = null;
   unsubOnTokenRefresh?.();
@@ -229,10 +262,15 @@ const disposeNotificationLayer = () => {
 
   // AppState 구독 해제
   if (unsubAppState) {
+    console.log('🗑️ [disposeNotificationLayer] AppState 구독 해제');
     unsubAppState();
     unsubAppState = null;
   }
+
   initialized = false;
+  channelCreated = false;
+
+  console.log('✅ [disposeNotificationLayer] 완료');
 };
 
 export { initNotificationLayer, ensurePermissionWatcher, disposeNotificationLayer, handleBackgroundMessage };


### PR DESCRIPTION
## 🤔 개요
Foreground 알림 노출 로직 구현이 필요함

## 📝 작업 내용
1. Foreground 알림 노출 로직 구현
2. eslint react-hooks/exhaustive-deps 레벨 warn으로 수정
3. 카메라/갤러리 권한 거부 했을 경우 권한 허용 관련 Dialog 추가
4. 회원 가입시, 광고성 정보 수신 미동의 했을 경우 동의 강조 관련 Dialog 추가
5. 회원 가입시, 알림 권한 상태 동기화 로직 추가
6. Task Form 스크린에 DatePicker 공통 컴포넌트 적용 및 초깃값, 버튼 비활성화 조건 추가

<!-- (선택)작업한 내용에 대해 달라진 화면을 스크린샷이나 동영상으로 첨부하여 보여주세요 
## 📸 작업 화면
<table>
<tr>
<td></td>
<td>AS-IS</td>
<td>TO-BE</td>
</tr>
<tr>
<td>🤖 AOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요 
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
<tr>
<td>🍎 IOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
</table>
-->

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-550](https://www.notion.so/Foreground-2d9df3a3e43f80af8b65e3bf4e953845?v=72865a96132e456c873537e8de4c3757&source=copy_link)
