### PR TITLE
[TAS-553]add: 둘러보기 - 인증 사진 모음 UI 구현 

### DIFF
--- a/src/components/Feed/SuccessTaskImageCard/index.tsx
+++ b/src/components/Feed/SuccessTaskImageCard/index.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
+import { theme } from 'styles/theme';
+import { SUCCESS_TASK_IMAGE_ITEM_WIDTH } from 'constants/Feed';
+
+const ITEM_HEIGHT = SUCCESS_TASK_IMAGE_ITEM_WIDTH * 1.3;
+
+// TODO: 인증 사진 리스트 API 타입 연동
+interface Props {
+  successImageUrl: string;
+  title: string;
+  profileImageUrl: string;
+  userName: string;
+}
+
+const SuccessTaskImageCard = ({ successImageUrl, title, profileImageUrl, userName }: Props) => (
+  <View style={styles.card}>
+    <Image source={{ uri: successImageUrl }} style={styles.successImage} />
+    <LinearGradient colors={['transparent', 'rgba(0, 0, 0, 0.8)']} style={styles.overlay}>
+      <Text style={styles.title} numberOfLines={1}>
+        {title}
+      </Text>
+      <View style={styles.profileRow}>
+        <Image source={{ uri: profileImageUrl }} style={styles.profileImage} />
+        <Text style={[theme.TYPOGRAPHY.CAPTION_2, { color: theme.COLORS.GRAY_SCALE.GRAY_70 }]}>{userName}</Text>
+      </View>
+    </LinearGradient>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  card: {
+    width: SUCCESS_TASK_IMAGE_ITEM_WIDTH,
+    height: ITEM_HEIGHT,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  successImage: {
+    width: '100%',
+    height: '100%',
+  },
+  overlay: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    paddingHorizontal: 12,
+    paddingBottom: 16,
+    borderBottomLeftRadius: 12,
+    borderBottomRightRadius: 12,
+  },
+  profileRow: {
+    marginTop: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  profileImage: {
+    width: 24,
+    height: 24,
+    borderRadius: 16,
+  },
+  title: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});
+
+export { SuccessTaskImageCard };

--- a/src/components/Feed/SuccessTaskImageList/index.tsx
+++ b/src/components/Feed/SuccessTaskImageList/index.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
+
+import { BlueCamera } from 'components/common/icons/BlueCamera';
+import { SuccessTaskImageCard } from 'components/Feed';
+import { theme } from 'styles/theme';
+import { SUCCESS_TASK_IMAGE_ITEM_GAP, SUCCESS_TASK_IMAGE_ITEM_WIDTH } from 'constants/Feed';
+
+const ItemSeparator = () => <View style={{ width: SUCCESS_TASK_IMAGE_ITEM_GAP }} />;
+const renderItem = ({ item }: { item: (typeof MOCK_SUCCESS_IMAGES)[number] }) => <SuccessTaskImageCard {...item} />;
+
+// TODO: 인증 사진 리스트 API 연동
+const MOCK_SUCCESS_IMAGES = [
+  {
+    successImageUrl: 'https://picsum.photos/seed/run/400/400',
+    title: '아침 5km 러닝 완료',
+    profileImageUrl: 'https://picsum.photos/seed/user1/100/100',
+    userName: '달리는사람',
+  },
+  {
+    successImageUrl: 'https://picsum.photos/seed/book/400/400',
+    title: '독서 30분 달성',
+    profileImageUrl: 'https://picsum.photos/seed/user2/100/100',
+    userName: '책벌레',
+  },
+  {
+    successImageUrl: 'https://picsum.photos/seed/gym/400/400',
+    title: '헬스장 루틴 완료',
+    profileImageUrl: 'https://picsum.photos/seed/user3/100/100',
+    userName: '근육맨',
+  },
+  {
+    successImageUrl: 'https://picsum.photos/seed/cook/400/400',
+    title: '도시락 직접 싸기 성공',
+    profileImageUrl: 'https://picsum.photos/seed/user4/100/100',
+    userName: '요리왕',
+  },
+  {
+    successImageUrl: 'https://picsum.photos/seed/study/400/400',
+    title: '알고리즘 문제 3개 풀기',
+    profileImageUrl: 'https://picsum.photos/seed/user5/100/100',
+    userName: '코딩마스터',
+  },
+  {
+    successImageUrl: 'https://picsum.photos/seed/yoga/400/400',
+    title: '아침 요가 스트레칭',
+    profileImageUrl: 'https://picsum.photos/seed/user6/100/100',
+    userName: '유연한몸',
+  },
+  {
+    successImageUrl: 'https://picsum.photos/seed/clean/400/400',
+    title: '방 청소 및 정리정돈',
+    profileImageUrl: 'https://picsum.photos/seed/user7/100/100',
+    userName: '깔끔대장',
+  },
+  {
+    successImageUrl: 'https://picsum.photos/seed/water/400/400',
+    title: '물 2L 마시기 달성',
+    profileImageUrl: 'https://picsum.photos/seed/user8/100/100',
+    userName: '수분충전',
+  },
+];
+
+const SuccessTaskImageList = () => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.titleSection}>
+        <BlueCamera />
+        <Text style={theme.TYPOGRAPHY.TITLE_2}>갓생 완료! 인증 사진 모음</Text>
+      </View>
+      <FlatList
+        data={MOCK_SUCCESS_IMAGES}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        snapToInterval={SUCCESS_TASK_IMAGE_ITEM_WIDTH + SUCCESS_TASK_IMAGE_ITEM_GAP}
+        decelerationRate="fast"
+        contentContainerStyle={styles.listContent}
+        ItemSeparatorComponent={ItemSeparator}
+        renderItem={renderItem}
+        keyExtractor={(_, index) => index.toString()}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 24,
+    backgroundColor: theme.COLORS.SECONDARY.BLUE_97,
+    gap: 24,
+  },
+  titleSection: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
+    paddingHorizontal: 20,
+  },
+  listContent: {
+    paddingHorizontal: 20,
+  },
+});
+
+export { SuccessTaskImageList };

--- a/src/components/Feed/index.ts
+++ b/src/components/Feed/index.ts
@@ -1,0 +1,2 @@
+export * from './SuccessTaskImageList';
+export * from './SuccessTaskImageCard';

--- a/src/components/common/icons/BlueCamera/index.tsx
+++ b/src/components/common/icons/BlueCamera/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Svg, { Circle, Rect, SvgProps } from 'react-native-svg';
+
+const BlueCamera = ({ width = 24, height = 24 }: Pick<SvgProps, 'width' | 'height'>) => (
+  <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+    <Rect x="5.1582" y="3.57812" width="13.6842" height="14.7368" rx="2" fill="#C4EBFF" />
+    <Rect x="2" y="5.68359" width="20" height="14.7368" rx="2" fill="#C4EBFF" />
+    <Circle cx="11.9996" cy="13.0504" r="4.21053" fill="#6DC4E3" />
+    <Circle cx="11.9998" cy="13.0506" r="2.10526" fill="#E5F6FF" />
+  </Svg>
+);
+export { BlueCamera };

--- a/src/constants/Feed/index.ts
+++ b/src/constants/Feed/index.ts
@@ -1,0 +1,6 @@
+import { Dimensions } from 'react-native';
+
+const SUCCESS_TASK_IMAGE_ITEM_GAP = 12;
+const SUCCESS_TASK_IMAGE_ITEM_WIDTH = (Dimensions.get('window').width - 40 - SUCCESS_TASK_IMAGE_ITEM_GAP) / 2;
+
+export { SUCCESS_TASK_IMAGE_ITEM_WIDTH, SUCCESS_TASK_IMAGE_ITEM_GAP };

--- a/src/screens/Feed/index.tsx
+++ b/src/screens/Feed/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
+
+import { SuccessTaskImageList } from 'components/Feed';
 
 const Feed = () => {
   return (
     <View>
-      <Text>Feed</Text>
+      <SuccessTaskImageList />
     </View>
   );
 };


### PR DESCRIPTION
## 🤔 개요
둘러보기 화면의 인증 사진 모음 UI를 구현해야 함

## 📝 작업 내용
둘러보기 화면의 인증 사진 모음 UI 구현

## 📸 작업 화면
<table>
<tr>
<td>🤖 AOS</td>
<td>🍎 IOS</td>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/982bccc5-2b10-40d5-a59f-971c910e823c
</td>
<td>

https://github.com/user-attachments/assets/576e02d3-78a1-418d-bc03-a07f46ea4ee7
</td>
</tr>
</table>

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-553](https://www.notion.so/UI-2e5df3a3e43f80cd8c4bc648ecd430ff?v=72865a96132e456c873537e8de4c3757&source=copy_link)