### PR TITLE
[TAS-598]add: 두윗모드 테스크 좋아요, 취소 API 연동 및 두윗 인증 사진 업로드 시 사용하는 Property 추가

### DIFF
--- a/src/components/Feed/SuccessTaskImageDetailItem/index.tsx
+++ b/src/components/Feed/SuccessTaskImageDetailItem/index.tsx
@@ -1,24 +1,25 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Dimensions, Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withSequence, withTiming } from 'react-native-reanimated';
 
 import { theme } from 'styles/theme';
 import { LikeIcon } from 'components/common/icons/LikeIcon';
+import { useLikeDowithTask } from 'hooks/queries/task/useLikeDowithTask';
 import type { successDowithTaskSchemeType } from 'types/task/scheme/api';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
 const SuccessTaskImageDetailItem = ({
+  id,
   successImageUrl,
   title,
   profileImageUrl,
   nickname,
-  isLiked: initialIsLiked,
+  isLiked,
   likeCount,
 }: successDowithTaskSchemeType) => {
-  const [isLiked, setIsLiked] = useState(initialIsLiked);
   const scale = useSharedValue(1);
-  const displayCount = likeCount + (isLiked && !initialIsLiked ? 1 : !isLiked && initialIsLiked ? -1 : 0);
+  const { mutate: likeDowithTask } = useLikeDowithTask();
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: scale.value }],
@@ -27,8 +28,9 @@ const SuccessTaskImageDetailItem = ({
   const handleLike = () => {
     if (!isLiked) {
       scale.value = withSequence(withTiming(1.4, { duration: 150 }), withTiming(1, { duration: 150 }));
+      likeDowithTask(id);
     }
-    setIsLiked(prev => !prev);
+    // TODO: 좋아요 취소 API 연동
   };
 
   return (
@@ -49,8 +51,8 @@ const SuccessTaskImageDetailItem = ({
             <Animated.View style={animatedStyle}>
               <LikeIcon {...(isLiked && { fill: theme.COLORS.STATUS.RED_55, stroke: theme.COLORS.STATUS.RED_55 })} />
             </Animated.View>
-            {displayCount > 0 && (
-              <Text style={[theme.TYPOGRAPHY.BODY_2, { color: theme.COLORS.DEFAULT.WHITE }]}>{displayCount}</Text>
+            {likeCount > 0 && (
+              <Text style={[theme.TYPOGRAPHY.BODY_2, { color: theme.COLORS.DEFAULT.WHITE }]}>{likeCount}</Text>
             )}
           </Pressable>
         </View>

--- a/src/components/Feed/SuccessTaskImageDetailItem/index.tsx
+++ b/src/components/Feed/SuccessTaskImageDetailItem/index.tsx
@@ -5,6 +5,7 @@ import Animated, { useSharedValue, useAnimatedStyle, withSequence, withTiming } 
 import { theme } from 'styles/theme';
 import { LikeIcon } from 'components/common/icons/LikeIcon';
 import { useLikeDowithTask } from 'hooks/queries/task/useLikeDowithTask';
+import { useUnLikeDowithTask } from 'hooks/queries/task/useUnLikeDowithTask';
 import type { successDowithTaskSchemeType } from 'types/task/scheme/api';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
@@ -20,17 +21,19 @@ const SuccessTaskImageDetailItem = ({
 }: successDowithTaskSchemeType) => {
   const scale = useSharedValue(1);
   const { mutate: likeDowithTask } = useLikeDowithTask();
+  const { mutate: unLikeDowithTask } = useUnLikeDowithTask();
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: scale.value }],
   }));
 
   const handleLike = () => {
-    if (!isLiked) {
+    if (isLiked) {
+      unLikeDowithTask(id);
+    } else {
       scale.value = withSequence(withTiming(1.4, { duration: 150 }), withTiming(1, { duration: 150 }));
       likeDowithTask(id);
     }
-    // TODO: 좋아요 취소 API 연동
   };
 
   return (

--- a/src/hooks/queries/task/useFetchUploadTaskSuccessImageUrlList.ts
+++ b/src/hooks/queries/task/useFetchUploadTaskSuccessImageUrlList.ts
@@ -18,9 +18,9 @@ const useUploadDowithTaskSuccessImageList = (id: number) => {
         return;
       }
 
-      // 1. Presigned URL 리스트 받기
+      // 1. 업로드 관련 URL 리스트 받기(public, presigned)
       const {
-        data: { presignedUrls },
+        data: { presignedUrls, publicImageUrls },
       } = await fetchUploadTaskSuccessImageUrlList(id, { imageFileNames });
 
       // 2. S3에 직접 이미지 업로드
@@ -30,7 +30,7 @@ const useUploadDowithTaskSuccessImageList = (id: number) => {
 
       // 3. 이미지 업로드 완료 API 호출
       await updateDowithTaskStatusSuccess(id, {
-        publicImageUrls: presignedUrls,
+        publicImageUrls,
       });
     },
     onSuccess: async () => {

--- a/src/hooks/queries/task/useLikeDowithTask.ts
+++ b/src/hooks/queries/task/useLikeDowithTask.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { TASK_QUERY_KEY } from 'constants/queries';
+import { likeDowithTask } from 'services/rest/task';
+import type {
+  fetchSuccessDowithTasksResponseSchemeType,
+  likeDowithTaskResponseSchemeType,
+} from 'types/task/scheme/api';
+
+const useLikeDowithTask = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<likeDowithTaskResponseSchemeType, AxiosError, number>({
+    mutationFn: dowithTaskId => likeDowithTask(dowithTaskId),
+    onSuccess: (res, dowithTaskId) => {
+      queryClient.setQueriesData<fetchSuccessDowithTasksResponseSchemeType>(
+        { queryKey: TASK_QUERY_KEY.SUCCESS_DOWITH_TASKS },
+        prev => {
+          if (!prev) {
+            return prev;
+          }
+          return {
+            ...prev,
+            data: {
+              successDowithTasks: prev.data.successDowithTasks.map(task =>
+                task.id === dowithTaskId
+                  ? // TODO: 좋아요 취소 API 연동 시 isAlreadyLiked 활용
+                    { ...task, isLiked: true, likeCount: res.data.likeCount }
+                  : task,
+              ),
+            },
+          };
+        },
+      );
+    },
+  });
+};
+
+export { useLikeDowithTask };

--- a/src/hooks/queries/task/useUnLikeDowithTask.ts
+++ b/src/hooks/queries/task/useUnLikeDowithTask.ts
@@ -2,17 +2,17 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { TASK_QUERY_KEY } from 'constants/queries';
-import { likeDowithTask } from 'services/rest/task';
+import { unLikeDowithTask } from 'services/rest/task';
 import type {
+  unLikeDowithTaskResponseSchemeType,
   fetchSuccessDowithTasksResponseSchemeType,
-  likeDowithTaskResponseSchemeType,
 } from 'types/task/scheme/api';
 
-const useLikeDowithTask = () => {
+const useUnLikeDowithTask = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<likeDowithTaskResponseSchemeType, AxiosError, number>({
-    mutationFn: dowithTaskId => likeDowithTask(dowithTaskId),
+  return useMutation<unLikeDowithTaskResponseSchemeType, AxiosError, number>({
+    mutationFn: dowithTaskId => unLikeDowithTask(dowithTaskId),
     onSuccess: (res, dowithTaskId) => {
       queryClient.setQueriesData<fetchSuccessDowithTasksResponseSchemeType>(
         { queryKey: TASK_QUERY_KEY.SUCCESS_DOWITH_TASKS },
@@ -24,7 +24,7 @@ const useLikeDowithTask = () => {
             ...prev,
             data: {
               successDowithTasks: prev.data.successDowithTasks.map(task =>
-                task.id === dowithTaskId ? { ...task, isLiked: true, likeCount: res.data.likeCount } : task,
+                task.id === dowithTaskId ? { ...task, isLiked: false, likeCount: res.data.likeCount } : task,
               ),
             },
           };
@@ -34,4 +34,4 @@ const useLikeDowithTask = () => {
   });
 };
 
-export { useLikeDowithTask };
+export { useUnLikeDowithTask };

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -100,7 +100,8 @@ const uploadTaskSuccessImageUrlListRequestScheme = z.object({
 
 const uploadTaskSuccessImageUrlListResponseScheme = BaseResponseScheme.extend({
   data: z.object({
-    presignedUrls: z.array(z.string()).describe('이미지 업로드 할 url 리스트'),
+    publicImageUrls: z.array(z.string()).describe('이미지 업로드 할 public url 리스트'),
+    presignedUrls: z.array(z.string()).describe('이미지 업로드 할 presigned url 리스트'),
     method: z.string(),
   }),
 });

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -119,6 +119,13 @@ const successDowithTaskScheme = z.object({
   likeCount: z.number().describe('좋아요 수'),
 });
 
+const likeDowithTaskResponseScheme = BaseResponseScheme.extend({
+  data: z.object({
+    isAlreadyLiked: z.boolean().describe('이미 좋아요가 눌려져있는지 여부'),
+    likeCount: z.number().describe('좋아요 수'),
+  }),
+});
+
 const fetchSuccessDowithTasksResponseScheme = BasePageResponseScheme.extend({
   data: z.object({
     successDowithTasks: z.array(successDowithTaskScheme),
@@ -147,5 +154,6 @@ export {
   uploadTaskSuccessImageUrlListResponseScheme,
   updateDowithTaskStatusSuccessRequestScheme,
   successDowithTaskScheme,
+  likeDowithTaskResponseScheme,
   fetchSuccessDowithTasksResponseScheme,
 };

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -126,6 +126,13 @@ const likeDowithTaskResponseScheme = BaseResponseScheme.extend({
   }),
 });
 
+const unLikeDowithTaskResponseScheme = BaseResponseScheme.extend({
+  data: z.object({
+    isAlreadyCanceled: z.boolean().describe('이미 좋아요 취소가 되어있는지 여부'),
+    likeCount: z.number().describe('좋아요 수'),
+  }),
+});
+
 const fetchSuccessDowithTasksResponseScheme = BasePageResponseScheme.extend({
   data: z.object({
     successDowithTasks: z.array(successDowithTaskScheme),
@@ -155,5 +162,6 @@ export {
   updateDowithTaskStatusSuccessRequestScheme,
   successDowithTaskScheme,
   likeDowithTaskResponseScheme,
+  unLikeDowithTaskResponseScheme,
   fetchSuccessDowithTasksResponseScheme,
 };

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -13,6 +13,7 @@ import type {
   fetchTodoTaskRequestSchemeType,
   fetchTodoTaskResponseSchemeType,
   fetchSuccessDowithTasksResponseSchemeType,
+  likeDowithTaskResponseSchemeType,
   updateTaskRequestSchemeType,
   updateTaskRoutineRequestSchemeType,
   updateTodoTaskStatusResponseSchemeType,
@@ -208,6 +209,17 @@ const fetchSuccessDowithTasks = async (
   }
 };
 
+const likeDowithTask = async (dowithTaskId: number): Promise<likeDowithTaskResponseSchemeType> => {
+  try {
+    const result = await apiClient.post<likeDowithTaskResponseSchemeType>(
+      TASK_API.LIKE_DOWITH.replace(':id', String(dowithTaskId)),
+    );
+    return result.data;
+  } catch (e) {
+    throw e;
+  }
+};
+
 export {
   fetchTaskCategoryList,
   fetchTaskList,
@@ -222,4 +234,5 @@ export {
   updateDowithTaskStatusSuccess,
   uploadFileToBucket,
   fetchSuccessDowithTasks,
+  likeDowithTask,
 };

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -14,6 +14,7 @@ import type {
   fetchTodoTaskResponseSchemeType,
   fetchSuccessDowithTasksResponseSchemeType,
   likeDowithTaskResponseSchemeType,
+  unLikeDowithTaskResponseSchemeType,
   updateTaskRequestSchemeType,
   updateTaskRoutineRequestSchemeType,
   updateTodoTaskStatusResponseSchemeType,
@@ -220,6 +221,17 @@ const likeDowithTask = async (dowithTaskId: number): Promise<likeDowithTaskRespo
   }
 };
 
+const unLikeDowithTask = async (dowithTaskId: number): Promise<unLikeDowithTaskResponseSchemeType> => {
+  try {
+    const result = await apiClient.delete<unLikeDowithTaskResponseSchemeType>(
+      TASK_API.LIKE_DOWITH.replace(':id', String(dowithTaskId)),
+    );
+    return result.data;
+  } catch (e) {
+    throw e;
+  }
+};
+
 export {
   fetchTaskCategoryList,
   fetchTaskList,
@@ -235,4 +247,5 @@ export {
   uploadFileToBucket,
   fetchSuccessDowithTasks,
   likeDowithTask,
+  unLikeDowithTask,
 };

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -20,6 +20,7 @@ const TASK_API = {
   UPLOAD_TASK_SUCCESS_IMAGE_URL_LIST: 'v1/tasks/dowith/:id/success/image/upload-presigned-url',
   SUCCESS_DOWITH: 'v1/tasks/dowith/:id/success',
   SUCCESS_DOWITH_TASKS: 'v1/tasks/dowith/success',
+  LIKE_DOWITH: 'v1/tasks/dowith/:id/like',
 } as const;
 
 const NOTIFICATION_API = {

--- a/src/types/task/scheme/api.ts
+++ b/src/types/task/scheme/api.ts
@@ -22,6 +22,7 @@ import {
   uploadTaskSuccessImageUrlListResponseScheme,
   updateDowithTaskStatusSuccessRequestScheme,
   successDowithTaskScheme,
+  likeDowithTaskResponseScheme,
   fetchSuccessDowithTasksResponseScheme,
 } from 'schemes/task/api';
 
@@ -46,6 +47,7 @@ type uploadTaskSuccessImageUrlListRequestSchemeType = z.infer<typeof uploadTaskS
 type uploadTaskSuccessImageUrlListResponseSchemeType = z.infer<typeof uploadTaskSuccessImageUrlListResponseScheme>;
 type updateDowithTaskStatusSuccessRequestSchemeType = z.infer<typeof updateDowithTaskStatusSuccessRequestScheme>;
 type successDowithTaskSchemeType = z.infer<typeof successDowithTaskScheme>;
+type likeDowithTaskResponseSchemeType = z.infer<typeof likeDowithTaskResponseScheme>;
 type fetchSuccessDowithTasksResponseSchemeType = z.infer<typeof fetchSuccessDowithTasksResponseScheme>;
 
 export type {
@@ -70,5 +72,6 @@ export type {
   uploadTaskSuccessImageUrlListResponseSchemeType,
   updateDowithTaskStatusSuccessRequestSchemeType,
   successDowithTaskSchemeType,
+  likeDowithTaskResponseSchemeType,
   fetchSuccessDowithTasksResponseSchemeType,
 };

--- a/src/types/task/scheme/api.ts
+++ b/src/types/task/scheme/api.ts
@@ -23,6 +23,7 @@ import {
   updateDowithTaskStatusSuccessRequestScheme,
   successDowithTaskScheme,
   likeDowithTaskResponseScheme,
+  unLikeDowithTaskResponseScheme,
   fetchSuccessDowithTasksResponseScheme,
 } from 'schemes/task/api';
 
@@ -48,6 +49,7 @@ type uploadTaskSuccessImageUrlListResponseSchemeType = z.infer<typeof uploadTask
 type updateDowithTaskStatusSuccessRequestSchemeType = z.infer<typeof updateDowithTaskStatusSuccessRequestScheme>;
 type successDowithTaskSchemeType = z.infer<typeof successDowithTaskScheme>;
 type likeDowithTaskResponseSchemeType = z.infer<typeof likeDowithTaskResponseScheme>;
+type unLikeDowithTaskResponseSchemeType = z.infer<typeof unLikeDowithTaskResponseScheme>;
 type fetchSuccessDowithTasksResponseSchemeType = z.infer<typeof fetchSuccessDowithTasksResponseScheme>;
 
 export type {
@@ -73,5 +75,6 @@ export type {
   updateDowithTaskStatusSuccessRequestSchemeType,
   successDowithTaskSchemeType,
   likeDowithTaskResponseSchemeType,
+  unLikeDowithTaskResponseSchemeType,
   fetchSuccessDowithTasksResponseSchemeType,
 };


### PR DESCRIPTION
## 🤔 개요
1. 인증 사진 모음에 사용되는 두윗모드 테스크 좋아요,취소 API를 연동해야 함
2. 두윗 인증 사진 업로드 시 사용하는 Property(`PublicImageUrls`) 추가하여 로직 수정이 필요함

## 📝 작업 내용
<!-- 작업한 내용을 정리하여 적어주세요 -->
1. 두윗모드 테스크 좋아요, 취소 API 연동
2. 두윗 인증 사진 업로드 시 사용하는 Property(`PublicImageUrls`) 추가하여 로직 수정

<!-- (선택)작업한 내용에 대해 달라진 화면을 스크린샷이나 동영상으로 첨부하여 보여주세요 
## 📸 작업 화면
<table>
<tr>
<td></td>
<td>AS-IS</td>
<td>TO-BE</td>
</tr>
<tr>
<td>🤖 AOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요 
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
<tr>
<td>🍎 IOS</td>
<td>

작업 전 스크린샷이나 동영상을 첨부해주세요
</td>
<td>

작업 후 스크린샷이나 동영상을 첨부해주세요
</td>
</tr>
</table>
-->

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-598](https://www.notion.so/API-31cdf3a3e43f80d0b5f5d0f45ff74fa6?v=72865a96132e456c873537e8de4c3757&source=copy_link)