### PR TITLE
[TAS-649]add: 둘러보기 > 잔소리 가능한 두윗 태스크 목록 조회 API 연동

### DIFF
--- a/src/components/Feed/FeedNagItem/index.tsx
+++ b/src/components/Feed/FeedNagItem/index.tsx
@@ -1,38 +1,46 @@
 import React, { useState } from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { Clock } from 'components/common/icons/Clock';
 import { Thunder } from 'components/common/icons/Thunder';
 import { PlusIcon } from 'components/common/icons/PlusIcon';
 import { CancelIcon } from 'components/common/icons/CancelIcon';
+import { TASK_QUERY_KEY } from 'constants/queries';
 import { theme } from 'styles/theme';
+import { formatRemainingTime } from 'utils/date';
 
 interface Props {
-  profileImageUrl: string;
+  badgeImageUrl: string;
   nickname: string;
-  taskDescription: string;
-  remainingTime: string;
-  nagCount: number;
+  title: string;
+  startTime: string;
+  feedbackCount: number;
 }
 
 const REACTION_EMOJIS = ['😆', '😡', '🤣', '👏'];
 
-const FeedNagItem = ({ profileImageUrl, nickname, taskDescription, remainingTime, nagCount }: Props) => {
+const FeedNagItem = ({ badgeImageUrl, nickname, title, startTime, feedbackCount }: Props) => {
+  const queryClient = useQueryClient();
   const [showReactions, setShowReactions] = useState(false);
   const [selectedEmoji, setSelectedEmoji] = useState<string | null>(null);
 
   const handleReaction = (emoji: string) => {
     setSelectedEmoji(emoji);
     setShowReactions(false);
+    // TODO: 피드백 전송 API 연동
+    queryClient.invalidateQueries({ queryKey: TASK_QUERY_KEY.FEEDBACK_AVAILABLE_DOWITH_TASKS });
   };
+
+  const remainingTime = formatRemainingTime(startTime);
 
   return (
     <View style={styles.container}>
       <View style={styles.topRow}>
-        <Image style={styles.image} source={{ uri: profileImageUrl }} />
+        <Image style={styles.image} source={{ uri: badgeImageUrl }} />
         <Text style={styles.nickname}>{nickname}</Text>
       </View>
-      <Text style={styles.taskDescription}>{taskDescription}</Text>
+      <Text style={styles.taskDescription}>{title}</Text>
       <View style={styles.bottomRow}>
         <View style={styles.infoRow}>
           <View style={styles.infoItem}>
@@ -41,7 +49,7 @@ const FeedNagItem = ({ profileImageUrl, nickname, taskDescription, remainingTime
           </View>
           <View style={styles.infoItem}>
             <Thunder width={12} height={12} fill={theme.COLORS.GRAY_SCALE.GRAY_80} />
-            <Text style={styles.info}>{nagCount}</Text>
+            <Text style={styles.info}>{feedbackCount}</Text>
           </View>
         </View>
         {selectedEmoji ? (

--- a/src/components/Feed/FeedNagItem/index.tsx
+++ b/src/components/Feed/FeedNagItem/index.tsx
@@ -43,10 +43,12 @@ const FeedNagItem = ({ badgeImageUrl, nickname, title, startTime, feedbackCount 
       <Text style={styles.taskDescription}>{title}</Text>
       <View style={styles.bottomRow}>
         <View style={styles.infoRow}>
-          <View style={styles.infoItem}>
-            <Clock width={12} height={12} fill={theme.COLORS.GRAY_SCALE.GRAY_80} />
-            <Text style={styles.info}>{remainingTime} 남음</Text>
-          </View>
+          {remainingTime ? (
+            <View style={styles.infoItem}>
+              <Clock width={12} height={12} fill={theme.COLORS.GRAY_SCALE.GRAY_80} />
+              <Text style={styles.info}>{remainingTime} 남음</Text>
+            </View>
+          ) : null}
           <View style={styles.infoItem}>
             <Thunder width={12} height={12} fill={theme.COLORS.GRAY_SCALE.GRAY_80} />
             <Text style={styles.info}>{feedbackCount}</Text>

--- a/src/components/Feed/FeedNagList/index.tsx
+++ b/src/components/Feed/FeedNagList/index.tsx
@@ -1,122 +1,53 @@
 import React from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { DoubleThunder } from 'components/common/icons/DoubleThunder';
 import { FeedNagItem } from 'components/Feed/FeedNagItem';
+import { useFetchFeedbackAvailableDowithTasks } from 'hooks/queries/task/useFetchFeedbackAvailableDowithTasks';
 import { theme } from 'styles/theme';
 
-// TODO: API 연동 후 제거
-const MOCK_DATA = [
-  {
-    id: 1,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=1',
-    nickname: '잔소리대장님',
-    taskDescription: '스트레칭하고 유산소 30분',
-    remainingTime: '2시간 30분',
-    nagCount: 11,
-  },
-  {
-    id: 2,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=2',
-    nickname: '갓생러님',
-    taskDescription: '영화 리스트 추리기',
-    remainingTime: '1시간 20분',
-    nagCount: 5,
-  },
-  {
-    id: 3,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=3',
-    nickname: '두윗마스터님',
-    taskDescription: '퇴근 후 선물 픽업',
-    remainingTime: '3시간',
-    nagCount: 8,
-  },
-  {
-    id: 4,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=4',
-    nickname: '열공러님',
-    taskDescription: '알고리즘 문제 2개 풀기',
-    remainingTime: '45분',
-    nagCount: 3,
-  },
-  {
-    id: 5,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=5',
-    nickname: '행복한호두',
-    taskDescription: '저녁 집밥 해먹기',
-    remainingTime: '4시간',
-    nagCount: 7,
-  },
-  {
-    id: 6,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=6',
-    nickname: '새벽감성님',
-    taskDescription: '독서 30분 하기',
-    remainingTime: '1시간 50분',
-    nagCount: 2,
-  },
-  {
-    id: 7,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=7',
-    nickname: '운동왕님',
-    taskDescription: '헬스장 가서 하체 루틴',
-    remainingTime: '2시간',
-    nagCount: 15,
-  },
-  {
-    id: 8,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=8',
-    nickname: '미라클모닝님',
-    taskDescription: '일기 쓰기',
-    remainingTime: '30분',
-    nagCount: 1,
-  },
-  {
-    id: 9,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=9',
-    nickname: '코딩마스터님',
-    taskDescription: '사이드 프로젝트 커밋 하나',
-    remainingTime: '5시간',
-    nagCount: 9,
-  },
-  {
-    id: 10,
-    profileImageUrl: 'https://i.pravatar.cc/150?img=10',
-    nickname: '정리왕님',
-    taskDescription: '방 청소하고 빨래 널기',
-    remainingTime: '1시간',
-    nagCount: 4,
-  },
-];
+const DISPLAY_COUNT = 5;
 
 const FeedNagList = () => {
+  const { data, isLoading } = useFetchFeedbackAvailableDowithTasks();
+
+  const allTasks = data?.dowithTasks ?? [];
+  const dowithTasks = allTasks.slice(0, DISPLAY_COUNT);
+  const hasMore = allTasks.length > DISPLAY_COUNT;
+
   return (
     <View style={styles.container}>
       <View style={styles.titleSection}>
         <DoubleThunder width={16} height={16} />
         <Text style={theme.TYPOGRAPHY.TITLE_2}>실시간 잔소리하기</Text>
       </View>
-      <View style={styles.list}>
-        {MOCK_DATA.slice(0, 5).map(item => (
-          <FeedNagItem
-            key={item.id}
-            profileImageUrl={item.profileImageUrl}
-            nickname={item.nickname}
-            taskDescription={item.taskDescription}
-            remainingTime={item.remainingTime}
-            nagCount={item.nagCount}
-          />
-        ))}
-      </View>
-      {MOCK_DATA.length > 5 && (
-        <Pressable
-          style={styles.moreButton}
-          onPress={() => {
-            // TODO: 실시간 잔소리하기 스크린으로 이동
-          }}
-        >
-          <Text style={styles.moreButtonText}>잔소리 더 하러가기</Text>
-        </Pressable>
+      {isLoading ? (
+        <ActivityIndicator />
+      ) : (
+        <>
+          <View style={styles.list}>
+            {dowithTasks.map(item => (
+              <FeedNagItem
+                key={item.id}
+                badgeImageUrl={item.badgeImageUrl}
+                nickname={item.nickname}
+                title={item.title}
+                startTime={item.startTime}
+                feedbackCount={item.feedbackCount}
+              />
+            ))}
+          </View>
+          {hasMore && (
+            <Pressable
+              style={styles.moreButton}
+              onPress={() => {
+                // TODO: 실시간 잔소리하기 스크린으로 이동
+              }}
+            >
+              <Text style={styles.moreButtonText}>잔소리 더 하러가기</Text>
+            </Pressable>
+          )}
+        </>
       )}
     </View>
   );

--- a/src/constants/queries/index.ts
+++ b/src/constants/queries/index.ts
@@ -18,6 +18,7 @@ const TASK_QUERY_KEY = {
   UPDATE: ['task', 'update'],
   UPDATE_ROUTINE: ['task', 'update', 'routine'],
   SUCCESS_DOWITH_TASKS: ['task', 'success', 'dowith'],
+  FEEDBACK_AVAILABLE_DOWITH_TASKS: ['task', 'feedback-available', 'dowith'],
 } as const;
 
 const NOTIFICATION_QUERY_KEY = {

--- a/src/hooks/queries/task/useFetchFeedbackAvailableDowithTasks.ts
+++ b/src/hooks/queries/task/useFetchFeedbackAvailableDowithTasks.ts
@@ -1,0 +1,27 @@
+import { AxiosError } from 'axios';
+import { useQuery } from '@tanstack/react-query';
+
+import { TASK_QUERY_KEY } from 'constants/queries';
+import { fetchFeedbackAvailableDowithTasks } from 'services/rest/task';
+import type { PageRequestSchemeType } from 'types/shared/scheme/api';
+import type {
+  fetchFeedbackAvailableDowithTasksResponseSchemeType,
+  feedbackAvailableDowithTaskSchemeType,
+} from 'types/task/scheme/api';
+
+type FeedbackAvailableDowithTasksResult = {
+  dowithTasks: feedbackAvailableDowithTaskSchemeType[];
+  totalCount: number;
+};
+
+const useFetchFeedbackAvailableDowithTasks = (params?: PageRequestSchemeType) =>
+  useQuery<fetchFeedbackAvailableDowithTasksResponseSchemeType, AxiosError, FeedbackAvailableDowithTasksResult>({
+    queryKey: [...TASK_QUERY_KEY.FEEDBACK_AVAILABLE_DOWITH_TASKS, params?.page, params?.size],
+    queryFn: () => fetchFeedbackAvailableDowithTasks(params),
+    select: data => ({
+      dowithTasks: data.data.dowithTasks,
+      totalCount: data.totalCount,
+    }),
+  });
+
+export { useFetchFeedbackAvailableDowithTasks };

--- a/src/schemes/task/api.ts
+++ b/src/schemes/task/api.ts
@@ -134,6 +134,24 @@ const unLikeDowithTaskResponseScheme = BaseResponseScheme.extend({
   }),
 });
 
+const feedbackAvailableDowithTaskScheme = z.object({
+  id: z.number().describe('Task ID'),
+  memberId: z.string().describe('작성자 member ID'),
+  nickname: z.string().describe('작성자 닉네임'),
+  badgeImageUrl: z.string().describe('뱃지 이미지 URL'),
+  title: z.string().describe('Task 제목'),
+  status: z.string().describe('Task 상태'),
+  date: z.string().describe('Task 수행일자'),
+  startTime: z.string().describe('Task 시작시간'),
+  feedbackCount: z.number().describe('피드백 수'),
+});
+
+const fetchFeedbackAvailableDowithTasksResponseScheme = BasePageResponseScheme.extend({
+  data: z.object({
+    dowithTasks: z.array(feedbackAvailableDowithTaskScheme),
+  }),
+});
+
 const fetchSuccessDowithTasksResponseScheme = BasePageResponseScheme.extend({
   data: z.object({
     successDowithTasks: z.array(successDowithTaskScheme),
@@ -161,6 +179,8 @@ export {
   uploadTaskSuccessImageUrlListRequestScheme,
   uploadTaskSuccessImageUrlListResponseScheme,
   updateDowithTaskStatusSuccessRequestScheme,
+  feedbackAvailableDowithTaskScheme,
+  fetchFeedbackAvailableDowithTasksResponseScheme,
   successDowithTaskScheme,
   likeDowithTaskResponseScheme,
   unLikeDowithTaskResponseScheme,

--- a/src/services/rest/task.ts
+++ b/src/services/rest/task.ts
@@ -10,6 +10,7 @@ import type {
   fetchTaskListResponseSchemeType,
   fetchTodoTaskRequestSchemeType,
   fetchTodoTaskResponseSchemeType,
+  fetchFeedbackAvailableDowithTasksResponseSchemeType,
   fetchSuccessDowithTasksResponseSchemeType,
   likeDowithTaskResponseSchemeType,
   unLikeDowithTaskResponseSchemeType,
@@ -216,6 +217,20 @@ const updateDowithTaskStatusSuccess = async (
   }
 };
 
+const fetchFeedbackAvailableDowithTasks = async (
+  params?: PageRequestSchemeType,
+): Promise<fetchFeedbackAvailableDowithTasksResponseSchemeType> => {
+  try {
+    const result = await apiClient.get<fetchFeedbackAvailableDowithTasksResponseSchemeType>(
+      TASK_API.FEEDBACK_AVAILABLE_DOWITH_TASKS,
+      { params },
+    );
+    return result.data;
+  } catch (e) {
+    throw e;
+  }
+};
+
 const fetchSuccessDowithTasks = async (
   params?: PageRequestSchemeType,
 ): Promise<fetchSuccessDowithTasksResponseSchemeType> => {
@@ -264,6 +279,7 @@ export {
   fetchUploadTaskSuccessImageUrlList,
   updateDowithTaskStatusSuccess,
   uploadFileToBucket,
+  fetchFeedbackAvailableDowithTasks,
   fetchSuccessDowithTasks,
   likeDowithTask,
   unLikeDowithTask,

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -23,6 +23,7 @@ const TASK_API = {
   SUCCESS_DOWITH: 'v1/tasks/dowith/:id/success',
   SUCCESS_DOWITH_TASKS: 'v1/tasks/dowith/success',
   LIKE_DOWITH: 'v1/tasks/dowith/:id/like',
+  FEEDBACK_AVAILABLE_DOWITH_TASKS: 'v1/tasks/dowith/feedback-available',
 } as const;
 
 const NOTIFICATION_API = {

--- a/src/types/task/scheme/api.ts
+++ b/src/types/task/scheme/api.ts
@@ -21,6 +21,8 @@ import {
   uploadTaskSuccessImageUrlListRequestScheme,
   uploadTaskSuccessImageUrlListResponseScheme,
   updateDowithTaskStatusSuccessRequestScheme,
+  feedbackAvailableDowithTaskScheme,
+  fetchFeedbackAvailableDowithTasksResponseScheme,
   successDowithTaskScheme,
   likeDowithTaskResponseScheme,
   unLikeDowithTaskResponseScheme,
@@ -47,6 +49,8 @@ type updateTaskRoutineRequestSchemeType = z.infer<typeof updateTaskRoutineReques
 type uploadTaskSuccessImageUrlListRequestSchemeType = z.infer<typeof uploadTaskSuccessImageUrlListRequestScheme>;
 type uploadTaskSuccessImageUrlListResponseSchemeType = z.infer<typeof uploadTaskSuccessImageUrlListResponseScheme>;
 type updateDowithTaskStatusSuccessRequestSchemeType = z.infer<typeof updateDowithTaskStatusSuccessRequestScheme>;
+type feedbackAvailableDowithTaskSchemeType = z.infer<typeof feedbackAvailableDowithTaskScheme>;
+type fetchFeedbackAvailableDowithTasksResponseSchemeType = z.infer<typeof fetchFeedbackAvailableDowithTasksResponseScheme>;
 type successDowithTaskSchemeType = z.infer<typeof successDowithTaskScheme>;
 type likeDowithTaskResponseSchemeType = z.infer<typeof likeDowithTaskResponseScheme>;
 type unLikeDowithTaskResponseSchemeType = z.infer<typeof unLikeDowithTaskResponseScheme>;
@@ -73,6 +77,8 @@ export type {
   uploadTaskSuccessImageUrlListRequestSchemeType,
   uploadTaskSuccessImageUrlListResponseSchemeType,
   updateDowithTaskStatusSuccessRequestSchemeType,
+  feedbackAvailableDowithTaskSchemeType,
+  fetchFeedbackAvailableDowithTasksResponseSchemeType,
   successDowithTaskSchemeType,
   likeDowithTaskResponseSchemeType,
   unLikeDowithTaskResponseSchemeType,

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -6,7 +6,7 @@ const formatRemainingTime = (startTime: string): string => {
   const diff = dayjs(target).diff(now, 'minute');
 
   if (diff <= 0) {
-    return '진행중';
+    return '';
   }
 
   const h = Math.floor(diff / 60);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,24 @@
+import dayjs from 'dayjs';
+
+const formatRemainingTime = (startTime: string): string => {
+  const now = dayjs();
+  const target = dayjs().format('YYYY-MM-DD') + ' ' + startTime;
+  const diff = dayjs(target).diff(now, 'minute');
+
+  if (diff <= 0) {
+    return '진행중';
+  }
+
+  const h = Math.floor(diff / 60);
+  const m = diff % 60;
+
+  if (h > 0 && m > 0) {
+    return `${h}시간 ${m}분`;
+  }
+  if (h > 0) {
+    return `${h}시간`;
+  }
+  return `${m}분`;
+};
+
+export { formatRemainingTime };


### PR DESCRIPTION
## 🤔 개요
<!-- 해당 작업을 하게 된 배경에 대해 적어주세요 -->
둘러보기 > 잔소리 가능한 두윗 태스크 목록 조회 API 연동이 필요함

## 📝 작업 내용
<!-- 작업한 내용을 정리하여 적어주세요 -->
둘러보기 > 잔소리 가능한 두윗 태스크 목록 조회 API 연동


## 📸 작업 화면
<table>
<tr>
<td>🤖 AOS</td>
<td>🍎 IOS</td>
</tr>
<tr>
<td>

<img width="354" height="774" alt="스크린샷 2026-04-05 오후 5 04 36" src="https://github.com/user-attachments/assets/6211741c-61a2-43ad-b80c-13153f2d9fdf" />
</td>
<td>

<img width="344" height="756" alt="스크린샷 2026-04-05 오후 5 04 50" src="https://github.com/user-attachments/assets/b263b772-1ba5-45be-b182-fbabd162d0d8" />
</td>
</tr>
</table>

## 📚 참고 및 관련 자료
<!-- 해당 작업에 관련된 자료들에 대한 링크를 첨부해주세요 
ex) [자료](자료 링크)
-->

## 🏷️ Task Ticket
<!-- Notion의 Task ID에 대한 링크를 적어주세요 
ex) [TAS-01](해당 Task ID 노션 링크)
-->
[TAS-649](https://www.notion.so/API-339df3a3e43f804fb160f7b5ab8f4153?v=72865a96132e456c873537e8de4c3757&source=copy_link)